### PR TITLE
🩹 remove duplicate initialization of macos_window_util

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,9 +14,6 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Window.initialize(); // flutter_acrylic
   await windowManager.ensureInitialized(); // window_manager
-  if (Platform.isMacOS) {
-    await WindowManipulator.initialize(); // macos_window_utils
-  }
 
   if (getListenerBackend() != null) {
     if (!getListenerBackend()!.initialize()) {


### PR DESCRIPTION
Since flutter_acrylic v1.1.4 already calls `WindowManipulator.initialize()` inside [`Window.initialize()`](https://github.com/alexmercerind/flutter_acrylic/blob/24343322cf3ad015132ef7ecbc7df570cb05125c/lib/window.dart#L55-L56), doing it again in `main.dart` causes a `Future already completed` error and prevents the app from starting.

```bash
2025-08-19 15:19:42.085 keyviz[35138:11491109] Running with merged UI and platform thread. Experimental.
flutter: The Dart VM service is listening on http://127.0.0.1:54622/rBBpDLrVdrk=/
[ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: Bad state: Future already completed
#0 _AsyncCompleter.complete (dart:async/future_impl.dart:97:31)
#1 WindowManipulator.initialize (package:macos_window_utils/window_manipulator.dart:51:16)
<asynchronous suspension>
#2 main (package:keyviz/main.dart:25:5)
<asynchronous suspension>
```
This pr removes the extra initialization.