### PR TITLE
fix Quit option in tray action

### DIFF
--- a/lib/providers/key_event.dart
+++ b/lib/providers/key_event.dart
@@ -890,7 +890,11 @@ class KeyEventProvider extends ChangeNotifier with TrayListener {
         break;
 
       case "quit":
-        windowManager.close();
+        try {
+          await trayManager.destroy();
+        } catch (_) {}
+        // Ensure the application terminates on all desktop platforms
+        exit(0);
         break;
     }
   }


### PR DESCRIPTION
Destroy tray before quitting and terminate the process to ensure a clean shutdown across macOS, Windows, and Linux. 

This prevents orphaned tray icons and makes the existing "Quit" menu entry work as expected.
Change limited to lib/providers/key_event.dart