### PR TITLE
feat: Add text mode for showing alphanumeric keys as text

### DIFF
--- a/src/components/key-overlay.tsx
+++ b/src/components/key-overlay.tsx
@@ -1,10 +1,13 @@
 import { easeInQuint, easeOutQuint } from "@/lib/utils";
+import { keymaps } from "@/lib/keymaps";
 import { useKeyEvent } from "@/stores/key_event";
 import { useKeyStyle } from "@/stores/key_style";
+import { RawKey } from "@/types/event";
 import { alignmentForColumn, alignmentForRow } from "@/types/style";
 import { AnimatePresence, motion, Variants } from "motion/react";
 import { useMemo } from "react";
 import { Keycap } from "./keycaps";
+import { KeyEvent } from "@/types/event";
 
 
 const fadeVariants: Variants = {
@@ -12,10 +15,65 @@ const fadeVariants: Variants = {
     hidden: { opacity: 0 },
 }
 
+type DisplayGroup =
+    | { type: "keys"; keys: KeyEvent[]; createdAt: number; lastGroupIndex: number; }
+    | { type: "text"; text: string; createdAt: number; lastGroupIndex: number; };
+
+const HARD_MODIFIERS = new Set<string>([
+    RawKey.ControlLeft,
+    RawKey.ControlRight,
+    RawKey.Alt,
+    RawKey.MetaLeft,
+    RawKey.MetaRight,
+]);
+
+const SOFT_MODIFIERS = new Set<string>([
+    RawKey.ShiftLeft,
+    RawKey.ShiftRight,
+    RawKey.CapsLock,
+]);
+
+const isPrintableKey = (event: KeyEvent) => {
+    if (event.name === RawKey.Space) return true;
+    const display = keymaps[event.name];
+    if (!display) return false;
+    if (display.category === "letter" || display.category === "digit" || display.category === "punctuation") {
+        return true;
+    }
+    if (display.category === "numpad") {
+        return typeof display.label === "string" && /^[0-9]$/.test(display.label);
+    }
+    return false;
+};
+
+const labelForText = (event: KeyEvent, textVariant: "text" | "text-short" | "icon") => {
+    if (event.name === RawKey.Space) return "⎵"; // "␣";
+    const display = keymaps[event.name];
+    if (!display) return "";
+    const baseLabel = textVariant === "text-short"
+        ? (display.shortLabel ?? display.label)
+        : display.label;
+
+    if (display.category === "letter") {
+        const upper = baseLabel.toUpperCase();
+        const lower = baseLabel.toLowerCase();
+        const useUpper = (event.capsLock || false) !== (event.shifted || false);
+        return useUpper ? upper : lower;
+    }
+
+    if (display.category === "digit" || display.category === "punctuation") {
+        if (event.shifted && display.symbol) return display.symbol;
+        return display.label;
+    }
+
+    return baseLabel;
+};
+
 export const KeyOverlay = () => {
     const pressedKeys = useKeyEvent(state => state.pressedKeys);
     const groups = useKeyEvent(state => state.groups);
     const showHistory = useKeyEvent(state => state.showEventHistory);
+    const textSequenceEnabled = useKeyEvent(state => state.textSequenceEnabled);
 
     const appearance = useKeyStyle(state => state.appearance);
     const text = useKeyStyle(state => state.text);
@@ -46,6 +104,80 @@ export const KeyOverlay = () => {
         }),
     }
 
+    const displayGroups = useMemo<DisplayGroup[]>(() => {
+        if (!textSequenceEnabled) {
+            return groups.map((group, index) => ({
+                type: "keys",
+                keys: group.keys,
+                createdAt: group.createdAt,
+                lastGroupIndex: index,
+            }));
+        }
+
+        const rendered: DisplayGroup[] = [];
+        let buffer: KeyEvent[] = [];
+        let bufferCreatedAt = 0;
+        let bufferLastIndex = -1;
+
+        const flushBuffer = () => {
+            if (buffer.length === 0) return;
+            const textValue = buffer
+                .map((event) => {
+                    const label = labelForText(event, text.variant);
+                    if (!label) return "";
+                    const repeatCount = Math.max(1, event.pressedCount);
+                    return label.repeat(repeatCount);
+                })
+                .join("");
+            rendered.push({
+                type: "text",
+                text: textValue,
+                createdAt: bufferCreatedAt,
+                lastGroupIndex: bufferLastIndex,
+            });
+            buffer = [];
+        };
+
+        groups.forEach((group, index) => {
+            const hasHardModifier = group.keys.some((event) => HARD_MODIFIERS.has(event.name));
+            if (hasHardModifier) {
+                flushBuffer();
+                rendered.push({
+                    type: "keys",
+                    keys: group.keys,
+                    createdAt: group.createdAt,
+                    lastGroupIndex: index,
+                });
+                return;
+            }
+
+            const groupHasPrintable = group.keys.some((event) => isPrintableKey(event));
+            for (const event of group.keys) {
+                if (groupHasPrintable && SOFT_MODIFIERS.has(event.name)) {
+                    continue;
+                }
+                if (isPrintableKey(event)) {
+                    if (buffer.length === 0) {
+                        bufferCreatedAt = group.createdAt;
+                    }
+                    buffer.push(event);
+                    bufferLastIndex = index;
+                } else {
+                    flushBuffer();
+                    rendered.push({
+                        type: "keys",
+                        keys: [event],
+                        createdAt: group.createdAt,
+                        lastGroupIndex: index,
+                    });
+                }
+            }
+        });
+
+        flushBuffer();
+        return rendered;
+    }, [groups, textSequenceEnabled, text.variant]);
+
     const variants = useMemo<Variants>(() => {
         switch (appearance.animation) {
             case "none":
@@ -73,23 +205,36 @@ export const KeyOverlay = () => {
         }
     }, [appearance.animation, text.size]);
 
+    const textGroupStyle: React.CSSProperties = {
+        color: text.color,
+        lineHeight: 1.2,
+        fontSize: text.size,
+        textTransform: "none",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        whiteSpace: "pre",
+    };
+
     if (appearance.animation === "none") {
         return (
             <div className="w-full h-full flex" style={containerStyle}>
-                {groups.map((group, groupIndex) => (
+                {displayGroups.map((group) => (
                     <div
-                        key={group.createdAt}
+                        key={`${group.createdAt}-${group.lastGroupIndex}-${group.type}`}
                         style={groupStyle}
                         className={background.enabled ? "overflow-hidden" : ""}
                     >
-                        {group.keys.map((event, keyIndex) => (
-                            <Keycap
-                                key={event.name}
-                                event={event}
-                                lastest={group.keys.length - 1 === keyIndex}
-                                isPressed={groups.length - 1 === groupIndex && event.in(pressedKeys)}
-                            />
-                        ))}
+                        {group.type === "text"
+                            ? <div style={textGroupStyle}>{group.text}</div>
+                            : group.keys.map((event, keyIndex) => (
+                                <Keycap
+                                    key={event.name}
+                                    event={event}
+                                    lastest={group.keys.length - 1 === keyIndex}
+                                    isPressed={groups.length - 1 === group.lastGroupIndex && event.in(pressedKeys)}
+                                />
+                            ))}
                     </div>
                 ))}
             </div>
@@ -99,9 +244,9 @@ export const KeyOverlay = () => {
     return (
         <div className="w-full h-full flex" style={containerStyle}>
             <AnimatePresence>
-                {groups.map((group, groupIndex) => (
+                {displayGroups.map((group) => (
                     <motion.div
-                        key={group.createdAt}
+                        key={`${group.createdAt}-${group.lastGroupIndex}-${group.type}`}
                         layout={showHistory ? "position" : false}
                         variants={fadeVariants}
                         initial="hidden"
@@ -115,27 +260,44 @@ export const KeyOverlay = () => {
                         }}
                     >
                         <AnimatePresence>
-                            {group.keys.map((event, keyIndex) => (
-                                <motion.div
-                                    key={event.name}
-                                    layout="position"
-                                    variants={variants}
-                                    initial="hidden"
-                                    animate="visible"
-                                    exit="hidden"
-                                    transition={{
-                                        ease: [easeOutQuint, easeInQuint],
-                                        duration: appearance.animationDuration,
-                                        layout: { duration: appearance.animationDuration / 3, ease: easeOutQuint },
-                                    }}
-                                >
-                                    <Keycap
-                                        event={event}
-                                        lastest={group.keys.length - 1 === keyIndex}
-                                        isPressed={groups.length - 1 === groupIndex && event.in(pressedKeys)}
-                                    />
-                                </motion.div>
-                            ))}
+                            {group.type === "text"
+                                ? (
+                                    <motion.div
+                                        layout="position"
+                                        variants={variants}
+                                        initial="hidden"
+                                        animate="visible"
+                                        exit="hidden"
+                                        transition={{
+                                            ease: [easeOutQuint, easeInQuint],
+                                            duration: appearance.animationDuration,
+                                            layout: { duration: appearance.animationDuration / 3, ease: easeOutQuint },
+                                        }}
+                                    >
+                                        <div style={textGroupStyle}>{group.text}</div>
+                                    </motion.div>
+                                )
+                                : group.keys.map((event, keyIndex) => (
+                                    <motion.div
+                                        key={event.name}
+                                        layout="position"
+                                        variants={variants}
+                                        initial="hidden"
+                                        animate="visible"
+                                        exit="hidden"
+                                        transition={{
+                                            ease: [easeOutQuint, easeInQuint],
+                                            duration: appearance.animationDuration,
+                                            layout: { duration: appearance.animationDuration / 3, ease: easeOutQuint },
+                                        }}
+                                    >
+                                        <Keycap
+                                            event={event}
+                                            lastest={group.keys.length - 1 === keyIndex}
+                                            isPressed={groups.length - 1 === group.lastGroupIndex && event.in(pressedKeys)}
+                                        />
+                                    </motion.div>
+                                ))}
                         </AnimatePresence>
                     </motion.div>
                 ))}

--- a/src/components/settings/general.tsx
+++ b/src/components/settings/general.tsx
@@ -28,7 +28,8 @@ export const GeneralSettings = () => {
         allowedKeys,
         showEventHistory, setShowEventHistory,
         maxHistory, setMaxHistory,
-        toggleShortcut, setToggleShortcut
+        toggleShortcut, setToggleShortcut,
+        textSequenceEnabled, setTextSequenceEnabled
     } = useKeyEvent();
 
     const direction = useKeyStyle(state => state.appearance.flexDirection);
@@ -93,6 +94,20 @@ export const GeneralSettings = () => {
             </ItemContent>
             <ItemActions>
                 <Switch checked={showEventHistory} onCheckedChange={setShowEventHistory} />
+            </ItemActions>
+        </Item>
+
+        <Item variant="muted">
+            <ItemContent>
+                <ItemTitle>
+                    <HugeiconsIcon icon={ToggleOnIcon} size="1em" /> Text Sequences
+                </ItemTitle>
+                <ItemDescription>
+                    Render sequential letters and digits as plain text when no modifiers are held
+                </ItemDescription>
+            </ItemContent>
+            <ItemActions>
+                <Switch checked={textSequenceEnabled} onCheckedChange={setTextSequenceEnabled} />
             </ItemActions>
         </Item>
 

--- a/src/components/settings/mouse.tsx
+++ b/src/components/settings/mouse.tsx
@@ -4,7 +4,7 @@ import { NumberInput } from "@/components/ui/number-input";
 import { Switch } from "@/components/ui/switch";
 import { useKeyEvent } from "@/stores/key_event";
 import { useKeyStyle } from '@/stores/key_style';
-import { ArrowExpand02Icon, Cursor01Icon, CursorCircleSelection01Icon, CursorEdit01Icon, CursorMagicSelection03FreeIcons, Drag03Icon, KeyboardIcon, Link02Icon, MouseLeftClick05Icon, PaintBoardIcon, Unlink02Icon } from "@hugeicons/core-free-icons";
+import { ArrowExpand02Icon, Cursor01Icon, CursorCircleSelection01Icon, CursorEdit01Icon, CursorMagicSelection03FreeIcons, Drag03Icon, Link02Icon, MouseLeftClick05Icon, PaintBoardIcon, Unlink02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { NumberScrubber } from "../ui/number-input-scrub";
 import { useState } from "react";

--- a/src/lib/keymaps.ts
+++ b/src/lib/keymaps.ts
@@ -315,8 +315,8 @@ export const keymaps: Record<string, DisplayData> = {
         category: "punctuation",
     },
     Slash: {
-        label: "?",
-        symbol: "/",
+        label: "/",
+        symbol: "?",
         category: "punctuation",
     },
     // ───────────── Numpad ─────────────

--- a/src/stores/key_event.ts
+++ b/src/stores/key_event.ts
@@ -4,6 +4,50 @@ import { createJSONStorage, persist } from "zustand/middleware";
 import { tauriStorage } from "./storage";
 import { createSyncedStore } from "./sync";
 
+const HARD_MODIFIERS = new Set<string>([
+    RawKey.ControlLeft,
+    RawKey.ControlRight,
+    RawKey.Alt,
+    RawKey.MetaLeft,
+    RawKey.MetaRight,
+]);
+
+const SOFT_MODIFIERS = new Set<string>([
+    RawKey.ShiftLeft,
+    RawKey.ShiftRight,
+]);
+
+const PUNCTUATION_KEYS = new Set<string>([
+    RawKey.BackQuote,
+    RawKey.Minus,
+    RawKey.Equal,
+    RawKey.LeftBracket,
+    RawKey.RightBracket,
+    RawKey.BackSlash,
+    RawKey.SemiColon,
+    RawKey.Quote,
+    RawKey.Comma,
+    RawKey.Dot,
+    RawKey.Slash,
+    RawKey.Space,
+    RawKey.KpDecimal,
+    RawKey.KpComma,
+    RawKey.KpDivide,
+    RawKey.KpMultiply,
+    RawKey.KpMinus,
+    RawKey.KpPlus,
+    RawKey.KpEqual,
+]);
+
+const isPrintableKeyName = (name: string) => {
+    if (name.startsWith("Key")) return true;
+    if (/^Num[0-9]$/.test(name)) return true;
+    if (name.startsWith("Kp") && /^Kp[0-9]$/.test(name)) return true;
+    return PUNCTUATION_KEYS.has(name);
+};
+
+const isHardModifierName = (name: string) => HARD_MODIFIERS.has(name);
+
 
 export const KEY_EVENT_STORE = "key_event_store";
 const SCROLL_LINGER_MS = 300;
@@ -36,6 +80,8 @@ export interface KeyEventState {
     maxHistory: number;
     lingerDurationMs: number;
     toggleShortcut: string[];
+    textSequenceEnabled: boolean;
+    capsLockOn: boolean;
 }
 
 interface KeyEventActions {
@@ -48,6 +94,7 @@ interface KeyEventActions {
     // setShowMouseEvents(value: KeyEventState["showMouseEvents"]): void;
     setLingerDurationMs(value: KeyEventState["lingerDurationMs"]): void;
     setToggleShortcut(value: KeyEventState["toggleShortcut"]): void;
+    setTextSequenceEnabled(value: KeyEventState["textSequenceEnabled"]): void;
     // ───────────── event actions ─────────────
     onEvent(event: EventPayload): void;
     onKeyPress(event: RawKeyEvent): void;
@@ -80,8 +127,10 @@ const createKeyEventStore = createSyncedStore<KeyEventStore>(
         ],
         showEventHistory: false,
         maxHistory: 5,
-        lingerDurationMs: 5_000,
+        lingerDurationMs: 3_000,
         toggleShortcut: [RawKey.ShiftLeft, RawKey.F10],
+        textSequenceEnabled: true,
+        capsLockOn: false,
 
         setDragThreshold(value: number) {
             set({ dragThreshold: value });
@@ -103,6 +152,9 @@ const createKeyEventStore = createSyncedStore<KeyEventStore>(
         },
         setToggleShortcut(value: string[]) {
             set({ toggleShortcut: value });
+        },
+        setTextSequenceEnabled(value: boolean) {
+            set({ textSequenceEnabled: value });
         },
         onEvent(event: EventPayload) {
             const state = get();
@@ -135,19 +187,76 @@ const createKeyEventStore = createSyncedStore<KeyEventStore>(
         },
         onKeyPress(event: RawKeyEvent) {
             const state = get();
+            const nextCapsLockOn = event.name === RawKey.CapsLock && event.pressed
+                ? !state.capsLockOn
+                : state.capsLockOn;
             // 0. track physical state
             const pressedKeys = [...state.pressedKeys];
             pressedKeys.push(event.name);
 
             // 1. filter event
             if (state.filter !== "none" && state.ignoreEvent(pressedKeys)) {
-                set({ pressedKeys });
+                if (nextCapsLockOn !== state.capsLockOn) {
+                    set({ pressedKeys, capsLockOn: nextCapsLockOn });
+                } else {
+                    set({ pressedKeys });
+                }
                 return;
             }
 
             let groups = [...state.groups];
             const last = groups.length - 1;
-            const key = new KeyEvent(event.name);
+            const shiftActive = pressedKeys.includes(RawKey.ShiftLeft) || pressedKeys.includes(RawKey.ShiftRight);
+            const key = new KeyEvent(event.name, { shifted: shiftActive, capsLock: nextCapsLockOn });
+
+            const hardModifierDown = pressedKeys.some((keyName) => isHardModifierName(keyName));
+            const textSequenceActive = state.textSequenceEnabled && isPrintableKeyName(key.name) && !hardModifierDown;
+
+            if (textSequenceActive) {
+                const createdAt = state.showEventHistory ? Date.now() : 0;
+                if (last < 0) {
+                    groups = [{ keys: [key], createdAt }];
+                } else {
+                    const lastGroup = groups[last];
+                    const canAppend = lastGroup.keys.every((gKey) => (
+                        isPrintableKeyName(gKey.name) || SOFT_MODIFIERS.has(gKey.name)
+                    ));
+                    if (canAppend) {
+                        let lastPrintableIndex = -1;
+                        for (let i = lastGroup.keys.length - 1; i >= 0; i -= 1) {
+                            if (isPrintableKeyName(lastGroup.keys[i].name)) {
+                                lastPrintableIndex = i;
+                                break;
+                            }
+                        }
+                        if (lastPrintableIndex >= 0) {
+                            const lastPrintable = lastGroup.keys[lastPrintableIndex];
+                            if (
+                                lastPrintable.name === key.name &&
+                                lastPrintable.shifted === key.shifted &&
+                                lastPrintable.capsLock === key.capsLock
+                            ) {
+                                lastPrintable.press();
+                            } else {
+                                lastGroup.keys.push(key);
+                            }
+                        } else {
+                            lastGroup.keys.push(key);
+                        }
+                    } else {
+                        if (state.showEventHistory) {
+                            groups.push({ keys: [key], createdAt });
+                        } else {
+                            groups = [{ keys: [key], createdAt }];
+                        }
+                    }
+                }
+                if (state.showEventHistory && groups.length > state.maxHistory) {
+                    groups = groups.slice(groups.length - state.maxHistory);
+                }
+                set({ pressedKeys, groups, capsLockOn: nextCapsLockOn });
+                return;
+            }
 
             // 2. check if pressed again
             const existingKey = last >= 0 ? groups[last].keys.find(gKey => gKey.name === key.name) : undefined;
@@ -157,7 +266,7 @@ const createKeyEventStore = createSyncedStore<KeyEventStore>(
                     const groupKeys: KeyEvent[] = [];
                     groups[last].keys.forEach(gKey => {
                         if (gKey.in(pressedKeys)) {
-                            groupKeys.push(new KeyEvent(gKey.name));
+                            groupKeys.push(new KeyEvent(gKey.name, { shifted: gKey.shifted, capsLock: gKey.capsLock }));
                         }
                     });
                     groups.push({ keys: groupKeys, createdAt: state.showEventHistory ? Date.now() : 0 });
@@ -207,7 +316,7 @@ const createKeyEventStore = createSyncedStore<KeyEventStore>(
                 groups = groups.slice(groups.length - state.maxHistory);
             }
 
-            set({ pressedKeys, groups });
+            set({ pressedKeys, groups, capsLockOn: nextCapsLockOn });
         },
         ignoreEvent(pressedKeys) {
             const state = get();
@@ -372,18 +481,40 @@ const createKeyEventStore = createSyncedStore<KeyEventStore>(
 
             // remove keys that have exceeded linger duration
             for (const group of state.groups) {
-                const updatedKeys = group.keys.filter((key) => {
-                    // keep key if
-                    return (
-                        // is pressed
-                        state.pressedKeys.includes(key.name) ||
-                        // within linger duration 
-                        now - key.lastPressedAt < state.lingerDurationMs
-                    );
-                })
-                if (updatedKeys.length !== group.keys.length) {
-                    notify = true;
+                const isTextSequence = state.textSequenceEnabled && group.keys.every((key) =>
+                    isPrintableKeyName(key.name) || SOFT_MODIFIERS.has(key.name)
+                );
+
+                let updatedKeys: KeyEvent[];
+
+                if (isTextSequence) {
+                    // For text sequences, remove expired keys from the left (FIFO)
+                    const expiredCount = group.keys.filter((key) =>
+                        !state.pressedKeys.includes(key.name) &&
+                        now - key.lastPressedAt >= state.lingerDurationMs
+                    ).length;
+
+                    if (expiredCount > 0) {
+                        updatedKeys = group.keys.slice(expiredCount);
+                        notify = true;
+                    } else {
+                        updatedKeys = group.keys;
+                    }
+                } else {
+                    updatedKeys = group.keys.filter((key) => {
+                        // keep key if
+                        return (
+                            // is pressed
+                            state.pressedKeys.includes(key.name) ||
+                            // within linger duration
+                            now - key.lastPressedAt < state.lingerDurationMs
+                        );
+                    });
+                    if (updatedKeys.length !== group.keys.length) {
+                        notify = true;
+                    }
                 }
+
                 if (updatedKeys.length > 0) {
                     groups.push({ keys: updatedKeys, createdAt: group.createdAt });
                 }
@@ -398,7 +529,7 @@ const createKeyEventStore = createSyncedStore<KeyEventStore>(
         name: KEY_EVENT_STORE,
         storage: createJSONStorage(() => tauriStorage),
         partialize: (state) => {
-            const { pressedKeys, pressedMouseButton, mouse, groups, settingsOpen, ...persistedState } = state;
+            const { pressedKeys, pressedMouseButton, mouse, groups, settingsOpen, capsLockOn, ...persistedState } = state;
             return persistedState;
         },
     }),

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -200,11 +200,15 @@ export class KeyEvent {
   name: string;
   pressedCount: number;
   lastPressedAt: number;
+  shifted: boolean;
+  capsLock: boolean;
 
-  constructor(name: string) {
+  constructor(name: string, options?: { shifted?: boolean; capsLock?: boolean }) {
     this.name = name;
     this.pressedCount = 1;
     this.lastPressedAt = Date.now();
+    this.shifted = options?.shifted ?? false;
+    this.capsLock = options?.capsLock ?? false;
   }
 
   press() {


### PR DESCRIPTION
Context: I had to demo a vim session but seeing the alphanumeric keys as keycaps is very unintuitive.

This PR adds a text mode, in which, the text is shown as - text, not keycaps.

Also, it changes the default behaviour of ``/`` key, which was treated as `?` in normal mode and `/` in shift mode, while in reality it is mostly opposite.

(ignore the low quality video - happened as artifact while converting mp4 to gif)
![keyviz-demo](https://github.com/user-attachments/assets/186f368c-8787-4c90-afc1-b487631a222e)

Since the feature was unasked, feel free to reject the PR.
And if you like the idea, I would request to add a proper "Vim mode" which renders all commands as vim renders shortcuts.