### PR TITLE
🩹 fix some bugs

### DIFF
--- a/src/stores/key_event.ts
+++ b/src/stores/key_event.ts
@@ -320,15 +320,29 @@ const createKeyEventStore = createSyncedStore<KeyEventStore>(
         onMouseWheel(event: MouseWheelEvent) {
             // bug: history mode, ctrl + scroll, scroll
             const state = get();
+            const wheel = Math.sign(event.delta_y);
+
+            if (wheel === 0) return;
+
+            const raw_key = wheel > 0 ? RawKey.ScrollUp : RawKey.ScrollDown;
+            const previous_raw_key = state.mouse.wheel > 0 ? RawKey.ScrollUp : RawKey.ScrollDown;
+
+            if (
+                state.mouse.wheel !== 0 &&
+                state.mouse.wheel !== wheel &&
+                state.pressedKeys.includes(previous_raw_key)
+            ) {
+                state.onKeyRelease({ type: "KeyEvent", name: previous_raw_key, pressed: false });
+            }
+
             // update mouse wheel state
             const mouse = {
                 ...state.mouse,
-                wheel: Math.sign(event.delta_y), // -1 for up, 1 for down
+                wheel, // -1 for down, 1 for up
                 lastScrollAt: Date.now()
             };
-            const raw_key = event.delta_y > 0 ? RawKey.ScrollUp : RawKey.ScrollDown;
             // simulate mouse wheel as key press
-            if (!state.pressedKeys.includes(raw_key)) {
+            if (!get().pressedKeys.includes(raw_key)) {
                 state.onKeyPress({ type: "KeyEvent", name: raw_key, pressed: true });
             }
 
@@ -344,8 +358,12 @@ const createKeyEventStore = createSyncedStore<KeyEventStore>(
 
             // handle scroll linger
             if (state.mouse.lastScrollAt && now - state.mouse.lastScrollAt > SCROLL_LINGER_MS) {
-                // simulate scroll key release
-                state.onKeyRelease({ type: "KeyEvent", name: state.mouse.wheel > 0 ? RawKey.ScrollUp : RawKey.ScrollDown, pressed: false });
+                if (state.pressedKeys.includes(RawKey.ScrollUp)) {
+                    state.onKeyRelease({ type: "KeyEvent", name: RawKey.ScrollUp, pressed: false });
+                }
+                if (state.pressedKeys.includes(RawKey.ScrollDown)) {
+                    state.onKeyRelease({ type: "KeyEvent", name: RawKey.ScrollDown, pressed: false });
+                }
                 set({ mouse: { ...state.mouse, wheel: 0, lastScrollAt: undefined } });
             }
 


### PR DESCRIPTION
Closes #442
Closes #447
Closes #449

## Summary

- Fixes [#447](https://github.com/mulaRahul/keyviz/issues/447) by normalizing Right Alt (`AltGr`) before emitting/tracking key events, so it shows up consistently in the overlay.
- Fixes [#442](https://github.com/mulaRahul/keyviz/issues/442) and [#449](https://github.com/mulaRahul/keyviz/issues/449) by releasing the previous virtual scroll key when the wheel direction reverses, and by clearing both `ScrollUp` / `ScrollDown` during linger cleanup.
- Also addresses the downstream report [zetaloop/keyviz#36](https://github.com/zetaloop/keyviz/issues/36), where `CapsLock` can remain stuck after being used for input-source switching on macOS.
- For context on the last point: this is not limited to one China-specific hardware variant. macOS can use `Caps Lock` to switch between Latin and non-Latin input sources, and some Chinese keyboards may also have a dedicated `中 / 英` switching key. Apple documents this behavior in the general input-source docs and the Chinese input-source docs:
  - https://support.apple.com/guide/mac-help/write-in-another-language-mchlp1406/mac
  - https://support.apple.com/guide/chinese-input-method/switch-to-a-chinese-or-cantonese-input-source-cim119a8d473/mac
- The `CapsLock` fix is intentionally small and store-level: it only clears a stale pressed state if no matching release arrives, instead of changing lower-level macOS event semantics.