### PR TITLE
Add i18n support, fix linger timing, and add topmost toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import "./App.css";
 
+import { I18nProvider, useI18n } from "./i18n";
 import { Suspense, lazy } from "react";
 import { HashRouter, Route, Routes } from "react-router-dom";
 import { ThemeProvider } from "./components/theme-provider";
@@ -8,10 +9,12 @@ import { Visualization } from "./pages/visualization";
 
 const Settings = lazy(() => import("./pages/settings"));
 
-function App() {
+function AppRoutes() {
+  const { t } = useI18n();
+
   return (
     <HashRouter>
-      <Suspense fallback={<div>Loading...</div>}>
+      <Suspense fallback={<div>{t("Loading...", "加载中...")}</div>}>
         <Routes>
           <Route path="/" element={<Visualization />} />
           <Route path="/settings" element={
@@ -23,6 +26,14 @@ function App() {
         </Routes>
       </Suspense>
     </HashRouter>
+  );
+}
+
+function App() {
+  return (
+    <I18nProvider>
+      <AppRoutes />
+    </I18nProvider>
   );
 }
 

--- a/src/components/keycaps/base.tsx
+++ b/src/components/keycaps/base.tsx
@@ -15,6 +15,8 @@ export const KeycapBase = ({ event }: { event: KeyEvent }) => {
     lineHeight: 1.2,
     fontSize: text.size,
     textTransform: text.caps,
+    fontVariantLigatures: "none",
+    fontFeatureSettings: "\"liga\" 0, \"calt\" 0",
   };
 
   const label = text.variant === "text-short"

--- a/src/components/settings/about.tsx
+++ b/src/components/settings/about.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button"
+import { useI18n } from "@/i18n"
 import { Item, ItemActions, ItemContent, ItemDescription, ItemTitle } from "@/components/ui/item"
 import { DiscordIcon, GithubIcon, LinkSquare02Icon, SparklesIcon, StarsIcon } from "@hugeicons/core-free-icons"
 import { HugeiconsIcon } from "@hugeicons/react"
@@ -10,6 +11,7 @@ import { toast } from "sonner"
 export const VERSION = "2.1.1"
 
 export const AboutPage = () => {
+    const { t } = useI18n();
     const [checking, setChecking] = useState(false);
     const [updateAvailable, setUpdateAvailable] = useState(false);
     const [hovered, setHovered] = useState(false);
@@ -27,16 +29,16 @@ export const AboutPage = () => {
             if (latestVersion !== VERSION) {
                 setUpdateAvailable(true);
                 toast.success(
-                    `New version available: v${latestVersion}`,
+                    t(`New version available: v${latestVersion}`, `发现新版本：v${latestVersion}`),
                     {
-                        action: { label: 'View', onClick: visitReleasePage }
+                        action: { label: t('View', '查看'), onClick: visitReleasePage }
                     }
                 );
             } else {
-                toast.info("You are using the latest version.");
+                toast.info(t("You are using the latest version.", "当前已是最新版本。"));
             }
         } catch (error) {
-            toast.error("Failed to check for updates.");
+            toast.error(t("Failed to check for updates.", "检查更新失败。"));
         }
         setChecking(false);
     }
@@ -105,10 +107,10 @@ export const AboutPage = () => {
                 >
                     <ItemContent>
                         <ItemTitle>
-                            <HugeiconsIcon icon={SparklesIcon} size="1em" /> Upgrade to Pro
+                            <HugeiconsIcon icon={SparklesIcon} size="1em" /> {t("Upgrade to Pro", "升级到 Pro")}
                         </ItemTitle>
                         <ItemDescription>
-                            Love Keyviz? Support its growth and unlock more with Pro.
+                            {t("Love Keyviz? Support its growth and unlock more with Pro.", "如果你喜欢 Keyviz，可以支持它继续发展，并通过 Pro 解锁更多功能。")}
                         </ItemDescription>
                     </ItemContent>
                     <ItemActions>
@@ -116,7 +118,7 @@ export const AboutPage = () => {
                             variant={hovered ? "default" : "outline"}
                             onClick={() => openUrl('https://keyviz.org/pro')}
                         >
-                            Go Pro
+                            {t("Go Pro", "前往升级")}
                         </Button>
                     </ItemActions>
                 </Item>
@@ -125,14 +127,14 @@ export const AboutPage = () => {
             <Item variant="muted" className="transition-all peer-hover:blur-xs">
                 <ItemContent>
                     <ItemTitle>
-                        <HugeiconsIcon icon={StarsIcon} size="1em" /> Check for updates
+                        <HugeiconsIcon icon={StarsIcon} size="1em" /> {t("Check for updates", "检查更新")}
                     </ItemTitle>
                 </ItemContent>
                 <ItemActions>
                     {
                         updateAvailable
-                            ? <Button className="cursor-pointer" onClick={visitReleasePage}>Update Available</Button>
-                            : <Button variant="outline" onClick={checkForUpdates} disabled={checking}>Check</Button>
+                            ? <Button className="cursor-pointer" onClick={visitReleasePage}>{t("Update Available", "有可用更新")}</Button>
+                            : <Button variant="outline" onClick={checkForUpdates} disabled={checking}>{t("Check", "检查")}</Button>
                     }
                 </ItemActions>
             </Item>
@@ -140,10 +142,10 @@ export const AboutPage = () => {
             <Item variant="muted" className="transition-all peer-hover:blur-xs">
                 <ItemContent>
                     <ItemTitle>
-                        <HugeiconsIcon icon={GithubIcon} size="1em" /> Open Source
+                        <HugeiconsIcon icon={GithubIcon} size="1em" /> {t("Open Source", "开源")}
                     </ItemTitle>
                     <ItemDescription className="max-w-100">
-                        Review the source code on GitHub, sponsor, star the project, or contribute to its development.
+                        {t("Review the source code on GitHub, sponsor, star the project, or contribute to its development.", "可以在 GitHub 查看源码、赞助项目、点 Star，或参与贡献。")}
                     </ItemDescription>
                 </ItemContent>
                 <ItemActions>
@@ -159,7 +161,7 @@ export const AboutPage = () => {
                         <HugeiconsIcon icon={DiscordIcon} size="1em" /> Discord
                     </ItemTitle>
                     <ItemDescription className="max-w-100">
-                        Join our Discord community.
+                        {t("Join our Discord community.", "加入我们的 Discord 社区。")}
                     </ItemDescription>
                 </ItemContent>
                 <ItemActions>

--- a/src/components/settings/appearance.tsx
+++ b/src/components/settings/appearance.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import { useI18n } from "@/i18n";
 import { AlignmentSelector } from "@/components/ui/alignment-selector";
 import { Item, ItemActions, ItemContent, ItemDescription, ItemTitle } from "@/components/ui/item";
 import { NumberInput } from "@/components/ui/number-input";
@@ -14,6 +15,7 @@ import { availableMonitors, Monitor } from "@tauri-apps/api/window";
 
 
 export const AppearanceSettings = () => {
+    const { t } = useI18n();
     const appearance = useKeyStyle(state => state.appearance);
     const setAppearance = useKeyStyle(state => state.setAppearance);
 
@@ -33,19 +35,19 @@ export const AppearanceSettings = () => {
     }, []);
 
     return <div className="flex flex-col gap-y-4 p-6">
-        <h1 className="text-xl font-semibold">Appearance</h1>
+        <h1 className="text-xl font-semibold">{t("Appearance", "外观")}</h1>
 
-        <h2 className="text-sm text-muted-foreground font-medium">Position</h2>
+        <h2 className="text-sm text-muted-foreground font-medium">{t("Position", "位置")}</h2>
         {
             monitors.length > 1 &&
             <Item variant="muted">
                 <ItemContent>
                     <ItemTitle>
                         <HugeiconsIcon icon={ComputerIcon} size="1em" />
-                        Display
+                        {t("Display", "显示器")}
                     </ItemTitle>
                     <ItemDescription>
-                        Change monitor/display for the visualisation.
+                        {t("Change monitor/display for the visualisation.", "切换按键显示所使用的显示器。")}
                     </ItemDescription>
                 </ItemContent>
                 <ItemActions>
@@ -56,7 +58,7 @@ export const AppearanceSettings = () => {
                         }}
                     >
                         <SelectTrigger className="w-32">
-                            <SelectValue placeholder="Select Display" />
+                            <SelectValue placeholder={t("Select Display", "选择显示器")} />
                         </SelectTrigger>
                         <SelectContent>
                             <SelectGroup>
@@ -77,10 +79,10 @@ export const AppearanceSettings = () => {
         <Item variant="muted">
             <ItemContent className="self-start">
                 <ItemTitle>
-                    <HugeiconsIcon icon={TextAlignLeftIcon} size="1em" /> Alignment
+                    <HugeiconsIcon icon={TextAlignLeftIcon} size="1em" /> {t("Alignment", "对齐")}
                 </ItemTitle>
                 <ItemDescription>
-                    Position of the key visualization on the screen
+                    {t("Position of the key visualization on the screen", "按键显示在屏幕上的位置")}
                 </ItemDescription>
             </ItemContent>
             <ItemActions>
@@ -96,10 +98,10 @@ export const AppearanceSettings = () => {
         <Item variant="muted">
             <ItemContent>
                 <ItemTitle>
-                    <HugeiconsIcon icon={ParagraphSpacingIcon} size="1em" /> Margin
+                    <HugeiconsIcon icon={ParagraphSpacingIcon} size="1em" /> {t("Margin", "边距")}
                 </ItemTitle>
                 <ItemDescription>
-                    Space from the edge of the screen
+                    {t("Space from the edge of the screen", "距离屏幕边缘的间距")}
                 </ItemDescription>
             </ItemContent>
             <ItemActions>
@@ -138,14 +140,14 @@ export const AppearanceSettings = () => {
             </ItemActions>
         </Item>
 
-        <h2 className="text-sm text-muted-foreground font-medium">Animation</h2>
+        <h2 className="text-sm text-muted-foreground font-medium">{t("Animation", "动画")}</h2>
         <Item variant="muted">
             <ItemContent>
                 <ItemTitle>
-                    <HugeiconsIcon icon={Time03Icon} size="1em" /> Duration
+                    <HugeiconsIcon icon={Time03Icon} size="1em" /> {t("Duration", "停留时长")}
                 </ItemTitle>
                 <ItemDescription className="max-w-84">
-                    The duration keys stay on screen (in seconds)
+                    {t("How long released keys stay on screen (in seconds)", "按键释放后在屏幕上保留的时间（秒）")}
                 </ItemDescription>
             </ItemContent>
             <ItemActions>
@@ -162,7 +164,7 @@ export const AppearanceSettings = () => {
         <Item variant="muted">
             <ItemContent>
                 <ItemTitle>
-                    <HugeiconsIcon icon={KeyframesDoubleIcon} size="1em" /> Animation
+                    <HugeiconsIcon icon={KeyframesDoubleIcon} size="1em" /> {t("Animation", "动画类型")}
                 </ItemTitle>
             </ItemContent>
             <ItemActions>
@@ -172,11 +174,11 @@ export const AppearanceSettings = () => {
                     </SelectTrigger>
                     <SelectContent>
                         <SelectGroup>
-                            <SelectItem value="none">None</SelectItem>
-                            <SelectItem value="fade">Fade</SelectItem>
-                            <SelectItem value="zoom">Zoom</SelectItem>
-                            <SelectItem value="float">Float</SelectItem>
-                            <SelectItem value="slide">Slide</SelectItem>
+                            <SelectItem value="none">{t("None", "无")}</SelectItem>
+                            <SelectItem value="fade">{t("Fade", "淡入淡出")}</SelectItem>
+                            <SelectItem value="zoom">{t("Zoom", "缩放")}</SelectItem>
+                            <SelectItem value="float">{t("Float", "上浮")}</SelectItem>
+                            <SelectItem value="slide">{t("Slide", "滑动")}</SelectItem>
                         </SelectGroup>
                     </SelectContent>
                 </Select>
@@ -186,10 +188,10 @@ export const AppearanceSettings = () => {
         <Item variant="muted">
             <ItemContent>
                 <ItemTitle>
-                    <HugeiconsIcon icon={KeyframesDoubleRemoveIcon} size="1em" /> Animation Speed
+                    <HugeiconsIcon icon={KeyframesDoubleRemoveIcon} size="1em" /> {t("Animation Speed", "动画速度")}
                 </ItemTitle>
                 <ItemDescription>
-                    Higher the value, slower the animation
+                    {t("Higher values make the animation slower", "数值越大，动画越慢")}
                 </ItemDescription>
             </ItemContent>
             <ItemActions>

--- a/src/components/settings/general.tsx
+++ b/src/components/settings/general.tsx
@@ -1,5 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 
+import { LanguageSelect } from "@/components/settings/language-select";
+import { useI18n } from "@/i18n";
 import { ShortcutRecorder } from '@/components/shortcut-recorder';
 import { Button } from '@/components/ui/button';
 import {
@@ -17,12 +19,13 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { cn } from "@/lib/utils";
 import { KeyEventState, useKeyEvent } from "@/stores/key_event";
 import { KeyStyleState, useKeyStyle } from "@/stores/key_style";
-import { ArrowHorizontalIcon, ArrowVerticalIcon, FilterHorizontalIcon, FilterIcon, LayerIcon, ToggleOnIcon } from "@hugeicons/core-free-icons";
+import { ArrowHorizontalIcon, ArrowVerticalIcon, FilterHorizontalIcon, FilterIcon, LayerIcon, Settings03Icon, ToggleOnIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { CustomFilter } from '../custom-filter';
 
 
 export const GeneralSettings = () => {
+    const { t } = useI18n();
     const {
         filter, setFilter,
         allowedKeys,
@@ -31,21 +34,53 @@ export const GeneralSettings = () => {
         toggleShortcut, setToggleShortcut
     } = useKeyEvent();
 
-    const direction = useKeyStyle(state => state.appearance.flexDirection);
+    const appearance = useKeyStyle(state => state.appearance);
+    const direction = appearance.flexDirection;
     const setAppearance = useKeyStyle(state => state.setAppearance);
 
     return <div className="flex flex-col gap-y-4 p-6">
-        <h1 className="text-xl font-semibold">General</h1>
+        <h1 className="text-xl font-semibold">{t("General", "通用")}</h1>
 
         <Item variant="muted">
             <ItemContent>
                 <ItemTitle>
-                    <HugeiconsIcon icon={FilterIcon} size="1em" /> Filter
+                    <HugeiconsIcon icon={Settings03Icon} size="1em" /> {t("Language", "语言")}
                 </ItemTitle>
                 <ItemDescription>
-                    {filter === 'none' && 'No filter applied, all keys will be shown.'}
-                    {filter === 'modifiers' && 'Only modifier keys will be shown.'}
-                    {filter === 'custom' && `Custom filter applied, ${allowedKeys.length} keys allowed.`}
+                    {t("Choose the app language or follow the system setting.", "选择应用语言，或跟随系统语言设置。")}
+                </ItemDescription>
+            </ItemContent>
+            <ItemActions>
+                <LanguageSelect />
+            </ItemActions>
+        </Item>
+
+        <Item variant="muted">
+            <ItemContent>
+                <ItemTitle>
+                    <HugeiconsIcon icon={LayerIcon} size="1em" /> {t("Always On Top", "窗口置顶")}
+                </ItemTitle>
+                <ItemDescription>
+                    {t("Keep the overlay above other windows.", "让按键显示层始终保持在其他窗口上方。")}
+                </ItemDescription>
+            </ItemContent>
+            <ItemActions>
+                <Switch
+                    checked={appearance.alwaysOnTop}
+                    onCheckedChange={(alwaysOnTop) => setAppearance({ alwaysOnTop })}
+                />
+            </ItemActions>
+        </Item>
+
+        <Item variant="muted">
+            <ItemContent>
+                <ItemTitle>
+                    <HugeiconsIcon icon={FilterIcon} size="1em" /> {t("Filter", "过滤")}
+                </ItemTitle>
+                <ItemDescription>
+                    {filter === 'none' && t('No filter applied, all keys will be shown.', '不过滤，显示所有按键。')}
+                    {filter === 'modifiers' && t('Only modifier keys will be shown.', '仅显示修饰键组合。')}
+                    {filter === 'custom' && t(`Custom filter applied, ${allowedKeys.length} keys allowed.`, `已启用自定义过滤，当前允许 ${allowedKeys.length} 个按键。`)}
                 </ItemDescription>
             </ItemContent>
             <ItemActions>
@@ -60,8 +95,8 @@ export const GeneralSettings = () => {
                         <DrawerContent>
                             <DrawerContent>
                                 <DrawerHeader>
-                                    <DrawerTitle>Custom Filter</DrawerTitle>
-                                    <DrawerDescription>Select which keys to display. Hold down Ctrl to toggle related keys.</DrawerDescription>
+                                    <DrawerTitle>{t("Custom Filter", "自定义过滤")}</DrawerTitle>
+                                    <DrawerDescription>{t("Select which keys to display. Hold down Ctrl to toggle related keys.", "选择要显示的按键。按住 Ctrl 可切换关联按键。")}</DrawerDescription>
                                 </DrawerHeader>
                                 <CustomFilter />
                             </DrawerContent>
@@ -75,9 +110,9 @@ export const GeneralSettings = () => {
                     value={filter}
                     onValueChange={(value) => setFilter(value as KeyEventState["filter"])}
                 >
-                    <ToggleGroupItem value="none" aria-label="No Filter">Off</ToggleGroupItem>
-                    <ToggleGroupItem value="modifiers" aria-label="Modifiers Only">Hotkeys</ToggleGroupItem>
-                    <ToggleGroupItem value="custom" aria-label="Custom Filter">Custom</ToggleGroupItem>
+                    <ToggleGroupItem value="none" aria-label={t("No Filter", "无过滤")}>{t("Off", "关闭")}</ToggleGroupItem>
+                    <ToggleGroupItem value="modifiers" aria-label={t("Modifiers Only", "仅修饰键")}>{t("Hotkeys", "快捷键")}</ToggleGroupItem>
+                    <ToggleGroupItem value="custom" aria-label={t("Custom Filter", "自定义过滤")}>{t("Custom", "自定义")}</ToggleGroupItem>
                 </ToggleGroup>
             </ItemActions>
         </Item>
@@ -85,10 +120,10 @@ export const GeneralSettings = () => {
         <Item variant="muted">
             <ItemContent>
                 <ItemTitle>
-                    <HugeiconsIcon icon={LayerIcon} size="1em" /> History
+                    <HugeiconsIcon icon={LayerIcon} size="1em" /> {t("History", "历史记录")}
                 </ItemTitle>
                 <ItemDescription>
-                    Keep previously pressed keystrokes in the view
+                    {t("Keep previously pressed keystrokes in the view", "在画面中保留之前按过的按键")}
                 </ItemDescription>
             </ItemContent>
             <ItemActions>
@@ -99,7 +134,7 @@ export const GeneralSettings = () => {
         <div className={cn("flex flex-col gap-4 md:flex-row", showEventHistory ? "" : "pointer-events-none opacity-50", "transition-opacity")}>
             <Item variant="muted" className="flex-7">
                 <ItemContent>
-                    <ItemTitle>Direction</ItemTitle>
+                    <ItemTitle>{t("Direction", "方向")}</ItemTitle>
                 </ItemContent>
                 <ItemActions>
                     <ToggleGroup
@@ -109,18 +144,18 @@ export const GeneralSettings = () => {
                         value={direction}
                         onValueChange={(value) => setAppearance({ flexDirection: value as KeyStyleState["appearance"]["flexDirection"] })}
                     >
-                        <ToggleGroupItem value="row" aria-label="Horizontal">
-                            <HugeiconsIcon icon={ArrowHorizontalIcon} strokeWidth={2} size={10} /> Row
+                        <ToggleGroupItem value="row" aria-label={t("Horizontal", "水平")}>
+                            <HugeiconsIcon icon={ArrowHorizontalIcon} strokeWidth={2} size={10} /> {t("Row", "横向")}
                         </ToggleGroupItem>
-                        <ToggleGroupItem value="column" aria-label="Vertical">
-                            <HugeiconsIcon icon={ArrowVerticalIcon} strokeWidth={2} /> Column
+                        <ToggleGroupItem value="column" aria-label={t("Vertical", "垂直")}>
+                            <HugeiconsIcon icon={ArrowVerticalIcon} strokeWidth={2} /> {t("Column", "纵向")}
                         </ToggleGroupItem>
                     </ToggleGroup>
                 </ItemActions>
             </Item>
             <Item variant="muted" className="flex-5">
                 <ItemContent>
-                    <ItemTitle>Max Count</ItemTitle>
+                    <ItemTitle>{t("Max Count", "最大数量")}</ItemTitle>
                 </ItemContent>
                 <ItemActions className="max-w-20">
                     <NumberInput className="h-8" value={maxHistory} onChange={setMaxHistory} minValue={2} maxValue={12} />
@@ -131,10 +166,10 @@ export const GeneralSettings = () => {
         <Item variant="muted">
             <ItemHeader className="flex-col items-start">
                 <ItemTitle>
-                    <HugeiconsIcon icon={ToggleOnIcon} size="1em" /> Toggle Shortcut
+                    <HugeiconsIcon icon={ToggleOnIcon} size="1em" /> {t("Toggle Shortcut", "切换快捷键")}
                 </ItemTitle>
                 <ItemDescription>
-                    Global shortcut to show/hide the key visualizer, click box to set
+                    {t("Global shortcut to show/hide the key visualizer, click box to set", "用于显示/隐藏按键可视化的全局快捷键，点击输入框设置")}
                 </ItemDescription>
             </ItemHeader>
             <ItemContent>

--- a/src/components/settings/keycap.tsx
+++ b/src/components/settings/keycap.tsx
@@ -1,6 +1,7 @@
 import { AlignmentSelector } from "@/components/ui/alignment-selector";
 import { Button } from "@/components/ui/button";
 import { ColorInput } from "@/components/ui/color-picker";
+import { useI18n } from "@/i18n";
 import { Item, ItemActions, ItemContent, ItemDescription, ItemGrid, ItemGroup, ItemTitle } from "@/components/ui/item";
 import { Label } from "@/components/ui/label";
 import { NumberInput } from "@/components/ui/number-input";
@@ -109,6 +110,7 @@ export const colorSchemes: KeycapTheme[] = [
 ];
 
 export const KeycapSettings = () => {
+    const { t } = useI18n();
     const appearance = useKeyStyle(state => state.appearance);
     const setAppearance = useKeyStyle(state => state.setAppearance);
 
@@ -169,9 +171,9 @@ export const KeycapSettings = () => {
     }
 
     return <div className="flex flex-col p-6 gap-y-4">
-        <h1 className="text-xl font-semibold">Keycap</h1>
+        <h1 className="text-xl font-semibold">{t("Keycap", "键帽")}</h1>
 
-        <h2 className="text-sm text-muted-foreground font-medium">Preset</h2>
+        <h2 className="text-sm text-muted-foreground font-medium">{t("Preset", "预设")}</h2>
         <Item variant="muted">
             <ItemActions className="w-full">
                 <Select value={appearance.style} onValueChange={onStyleChange}>
@@ -180,9 +182,9 @@ export const KeycapSettings = () => {
                     </SelectTrigger>
                     <SelectContent>
                         <SelectGroup>
-                            <SelectItem value="minimal">Minimal</SelectItem>
-                            <SelectItem value="laptop">Laptop</SelectItem>
-                            <SelectItem value="lowprofile">Lowprofile</SelectItem>
+                            <SelectItem value="minimal">{t("Minimal", "极简")}</SelectItem>
+                            <SelectItem value="laptop">{t("Laptop", "笔记本")}</SelectItem>
+                            <SelectItem value="lowprofile">{t("Lowprofile", "低矮")}</SelectItem>
                             <SelectItem value="pbt" >PBT</SelectItem>
                         </SelectGroup>
                     </SelectContent>
@@ -220,17 +222,17 @@ export const KeycapSettings = () => {
                 </Button>
 
                 <Button variant="outline" size="sm" className="ml-auto" onClick={importStyle}>
-                    <HugeiconsIcon icon={Download01Icon} className="mr-2" /> Import
+                    <HugeiconsIcon icon={Download01Icon} className="mr-2" /> {t("Import", "导入")}
                 </Button>
                 <Button variant="outline" size="sm" onClick={exportStyle}>
-                    <HugeiconsIcon icon={Upload01Icon} className="mr-2" /> Export
+                    <HugeiconsIcon icon={Upload01Icon} className="mr-2" /> {t("Export", "导出")}
                 </Button>
             </ItemActions>
         </Item>
 
         <Collapsible defaultOpen={true}>
             <CollapsibleTrigger>
-                <h2 className="text-sm text-muted-foreground font-medium">Text</h2>
+                <h2 className="text-sm text-muted-foreground font-medium">{t("Text", "文字")}</h2>
             </CollapsibleTrigger>
             <CollapsibleContent className="flex flex-col gap-y-4 pt-4">
                 <ItemGrid className="md:grid-cols-[240px_1fr]">
@@ -242,7 +244,7 @@ export const KeycapSettings = () => {
                     <ItemGroup>
                         <Item variant="muted" className="flex-2">
                             <ItemContent>
-                                <ItemTitle>Size</ItemTitle>
+                                <ItemTitle>{t("Size", "尺寸")}</ItemTitle>
                             </ItemContent>
                             <ItemActions>
                                 <NumberInput
@@ -254,7 +256,7 @@ export const KeycapSettings = () => {
                         </Item>
                         <Item variant="muted" className="flex-2">
                             <ItemContent>
-                                <ItemTitle>Variant</ItemTitle>
+                                <ItemTitle>{t("Variant", "样式")}</ItemTitle>
                             </ItemContent>
                             <ItemActions>
                                 <Select value={text.variant} onValueChange={(value) => {
@@ -267,9 +269,9 @@ export const KeycapSettings = () => {
                                         <SelectValue placeholder="text variant" />
                                     </SelectTrigger>
                                     <SelectContent>
-                                        <SelectItem value="text">Full Text</SelectItem>
-                                        <SelectItem value="text-short">Short Text</SelectItem>
-                                        <SelectItem value="icon">Icon Only</SelectItem>
+                                        <SelectItem value="text">{t("Full Text", "完整文字")}</SelectItem>
+                                        <SelectItem value="text-short">{t("Short Text", "短文字")}</SelectItem>
+                                        <SelectItem value="icon">{t("Icon Only", "仅图标")}</SelectItem>
                                     </SelectContent>
                                 </Select>
 
@@ -277,7 +279,7 @@ export const KeycapSettings = () => {
                         </Item>
                         <Item variant="muted" className="flex-2">
                             <ItemContent>
-                                <ItemTitle>Text Cap</ItemTitle>
+                                <ItemTitle>{t("Text Case", "大小写")}</ItemTitle>
                             </ItemContent>
                             <ItemActions>
                                 <ToggleGroup
@@ -297,7 +299,7 @@ export const KeycapSettings = () => {
                 <ItemGrid>
                     <Item variant="muted" className={modifier.highlight ? "" : "col-span-2"}>
                         <ItemContent>
-                            <ItemTitle>Text Color</ItemTitle>
+                            <ItemTitle>{t("Text Color", "文字颜色")}</ItemTitle>
                         </ItemContent>
                         <ItemActions>
                             <ColorInput value={text.color} onChange={(color) => setTextStyle({ color })} />
@@ -307,7 +309,7 @@ export const KeycapSettings = () => {
                         modifier.highlight &&
                         <Item variant="muted">
                             <ItemContent>
-                                <ItemTitle>Modifier Color</ItemTitle>
+                                <ItemTitle>{t("Modifier Color", "修饰键颜色")}</ItemTitle>
                             </ItemContent>
                             <ItemActions>
                                 <ColorInput value={modifier.textColor} onChange={(textColor) => setModifierStyle({ textColor })} />
@@ -320,13 +322,13 @@ export const KeycapSettings = () => {
 
         <Collapsible>
             <CollapsibleTrigger>
-                <h2 className="text-sm text-muted-foreground font-medium">Layout</h2>
+                <h2 className="text-sm text-muted-foreground font-medium">{t("Layout", "布局")}</h2>
             </CollapsibleTrigger>
             <CollapsibleContent className="flex flex-col gap-y-4 pt-4">
                 <ItemGrid>
                     <Item variant="muted">
                         <ItemContent>
-                            <ItemTitle>Icon</ItemTitle>
+                            <ItemTitle>{t("Icon", "图标")}</ItemTitle>
                         </ItemContent>
                         <ItemActions>
                             <Switch
@@ -338,7 +340,7 @@ export const KeycapSettings = () => {
                     </Item>
                     <Item variant="muted">
                         <ItemContent>
-                            <ItemTitle>Alignment</ItemTitle>
+                            <ItemTitle>{t("Alignment", "对齐")}</ItemTitle>
                         </ItemContent>
                         <ItemActions>
                             <ToggleGroup
@@ -364,8 +366,8 @@ export const KeycapSettings = () => {
                 </ItemGrid>
                 <Item variant="muted">
                     <ItemContent>
-                        <ItemTitle>Symbol</ItemTitle>
-                        <ItemDescription>Display symbol characters like !, @, #, etc.</ItemDescription>
+                        <ItemTitle>{t("Symbol", "符号")}</ItemTitle>
+                        <ItemDescription>{t("Display symbol characters like !, @, #, etc.", "显示 !、@、# 等符号字符。")}</ItemDescription>
                     </ItemContent>
                     <ItemActions>
                         <Switch
@@ -378,8 +380,8 @@ export const KeycapSettings = () => {
                     appearance.style !== "minimal" &&
                     <Item variant="muted">
                         <ItemContent>
-                            <ItemTitle>Press Count</ItemTitle>
-                            <ItemDescription>Display the number of times a key has been pressed.</ItemDescription>
+                            <ItemTitle>{t("Press Count", "按下次数")}</ItemTitle>
+                            <ItemDescription>{t("Display the number of times a key has been pressed.", "显示按键被按下的次数。")}</ItemDescription>
                         </ItemContent>
                         <ItemActions>
                             <Switch
@@ -396,13 +398,13 @@ export const KeycapSettings = () => {
             appearance.style !== "minimal" &&
             <Collapsible>
                 <CollapsibleTrigger>
-                    <h2 className="text-sm text-muted-foreground font-medium">Color</h2>
+                    <h2 className="text-sm text-muted-foreground font-medium">{t("Color", "颜色")}</h2>
                 </CollapsibleTrigger>
                 <CollapsibleContent className="flex flex-col gap-y-4 pt-4">
                     <Item variant="muted">
                         <ItemContent>
-                            <ItemTitle>Highlight Modifier</ItemTitle>
-                            <ItemDescription>Use different color for modifier keys</ItemDescription>
+                            <ItemTitle>{t("Highlight Modifier", "高亮修饰键")}</ItemTitle>
+                            <ItemDescription>{t("Use different color for modifier keys", "为修饰键使用不同颜色")}</ItemDescription>
                         </ItemContent>
                         <ItemActions>
                             <Switch checked={modifier.highlight} onCheckedChange={(highlight) => setModifierStyle({ highlight })} />
@@ -412,7 +414,7 @@ export const KeycapSettings = () => {
                         appearance.style !== "lowprofile" &&
                         <Item variant="muted">
                             <ItemContent>
-                                <ItemTitle>Gradient</ItemTitle>
+                                <ItemTitle>{t("Gradient", "渐变")}</ItemTitle>
                             </ItemContent>
                             <ItemActions>
                                 <Switch
@@ -427,7 +429,7 @@ export const KeycapSettings = () => {
                             <ItemGrid>
                                 <Item variant="muted" className={modifier.highlight ? "" : "col-span-2"}>
                                     <ItemContent>
-                                        <ItemTitle>Normal</ItemTitle>
+                                        <ItemTitle>{t("Normal", "普通键")}</ItemTitle>
                                     </ItemContent>
                                     <ItemActions>
                                         <ColorInput value={color.color} onChange={(color) => setColorStyle({ color })} />
@@ -437,7 +439,7 @@ export const KeycapSettings = () => {
                                     modifier.highlight &&
                                     <Item variant="muted">
                                         <ItemContent>
-                                            <ItemTitle>Modifier</ItemTitle>
+                                                <ItemTitle>{t("Modifier", "修饰键")}</ItemTitle>
                                         </ItemContent>
                                         <ItemActions>
                                             <ColorInput value={modifier.color} onChange={(color) => setModifierStyle({ color })} />
@@ -446,11 +448,11 @@ export const KeycapSettings = () => {
                                 }
                             </ItemGrid> :
                             <>
-                                {modifier.highlight && <h1>Normal Color</h1>}
+                                {modifier.highlight && <h1>{t("Normal Color", "普通键颜色")}</h1>}
                                 <ItemGrid>
                                     <Item variant="muted">
                                         <ItemContent>
-                                            <ItemTitle>Primary</ItemTitle>
+                                            <ItemTitle>{t("Primary", "主色")}</ItemTitle>
                                         </ItemContent>
                                         <ItemActions>
                                             <ColorInput
@@ -461,7 +463,7 @@ export const KeycapSettings = () => {
                                     </Item>
                                     <Item variant="muted">
                                         <ItemContent>
-                                            <ItemTitle>Secondary</ItemTitle>
+                                            <ItemTitle>{t("Secondary", "辅色")}</ItemTitle>
                                         </ItemContent>
                                         <ItemActions>
                                             <ColorInput
@@ -473,11 +475,11 @@ export const KeycapSettings = () => {
                                 </ItemGrid>
                                 {
                                     modifier.highlight && <>
-                                        <h1>Modifier Color</h1>
+                                        <h1>{t("Modifier Color", "修饰键颜色")}</h1>
                                         <ItemGrid>
                                             <Item variant="muted">
                                                 <ItemContent>
-                                                    <ItemTitle>Primary</ItemTitle>
+                                                    <ItemTitle>{t("Primary", "主色")}</ItemTitle>
                                                 </ItemContent>
                                                 <ItemActions>
                                                     <ColorInput
@@ -488,7 +490,7 @@ export const KeycapSettings = () => {
                                             </Item>
                                             <Item variant="muted">
                                                 <ItemContent>
-                                                    <ItemTitle>Secondary</ItemTitle>
+                                                    <ItemTitle>{t("Secondary", "辅色")}</ItemTitle>
                                                 </ItemContent>
                                                 <ItemActions>
                                                     <ColorInput
@@ -508,13 +510,13 @@ export const KeycapSettings = () => {
 
         <Collapsible>
             <CollapsibleTrigger>
-                <h2 className="text-sm text-muted-foreground font-medium">Border</h2>
+                <h2 className="text-sm text-muted-foreground font-medium">{t("Border", "边框")}</h2>
             </CollapsibleTrigger>
             <CollapsibleContent className="flex flex-col gap-y-4 pt-4">
                 <ItemGrid>
                     <Item variant="muted">
                         <ItemContent className="min-h-6 h-full justify-center">
-                            <ItemTitle>Enable</ItemTitle>
+                            <ItemTitle>{t("Enable", "启用")}</ItemTitle>
                         </ItemContent>
                         <ItemActions>
                             <Switch id="borderEnabled" checked={border.enabled} onCheckedChange={(enabled) => setBorderStyle({ enabled })} />
@@ -522,7 +524,7 @@ export const KeycapSettings = () => {
                     </Item>
                     <Item variant="muted">
                         <ItemContent>
-                            <ItemTitle>Width</ItemTitle>
+                            <ItemTitle>{t("Width", "宽度")}</ItemTitle>
                         </ItemContent>
                         <ItemActions>
                             <NumberInput
@@ -537,7 +539,7 @@ export const KeycapSettings = () => {
                     </Item>
                     <Item variant="muted" className={modifier.highlight ? "" : "col-span-2"}>
                         <ItemContent>
-                            <ItemTitle>Color</ItemTitle>
+                            <ItemTitle>{t("Color", "颜色")}</ItemTitle>
                         </ItemContent>
                         <ItemActions>
                             <ColorInput
@@ -550,7 +552,7 @@ export const KeycapSettings = () => {
                     {
                         modifier.highlight && <Item variant="muted">
                             <ItemContent>
-                                <ItemTitle>Modifier Color</ItemTitle>
+                                <ItemTitle>{t("Modifier Color", "修饰键颜色")}</ItemTitle>
                             </ItemContent>
                             <ItemActions>
                                 <ColorInput
@@ -564,7 +566,7 @@ export const KeycapSettings = () => {
                 </ItemGrid>
                 <Item variant="muted">
                     <ItemContent>
-                        <ItemTitle>Radius</ItemTitle>
+                        <ItemTitle>{t("Radius", "圆角")}</ItemTitle>
                     </ItemContent>
                     <ItemActions>
                         <div className="w-4 h-4 border-l-2 border-t-2 border-primary/50" style={{ borderTopLeftRadius: `${border.radius * 100}%` }} />
@@ -584,13 +586,13 @@ export const KeycapSettings = () => {
 
         <Collapsible>
             <CollapsibleTrigger>
-                <h2 className="text-sm text-muted-foreground font-medium">Background</h2>
+                <h2 className="text-sm text-muted-foreground font-medium">{t("Background", "背景")}</h2>
             </CollapsibleTrigger>
             <CollapsibleContent className="flex flex-col gap-y-4 pt-4">
                 <ItemGrid>
                     <Item variant="muted">
                         <ItemContent className="min-h-6 h-full justify-center">
-                            <ItemTitle>Enable</ItemTitle>
+                            <ItemTitle>{t("Enable", "启用")}</ItemTitle>
                         </ItemContent>
                         <ItemActions>
                             <Switch checked={background.enabled} onCheckedChange={(enabled) => setBackgroundStyle({ enabled })} />
@@ -598,7 +600,7 @@ export const KeycapSettings = () => {
                     </Item>
                     <Item variant="muted">
                         <ItemContent>
-                            <ItemTitle>Color</ItemTitle>
+                            <ItemTitle>{t("Color", "颜色")}</ItemTitle>
                         </ItemContent>
                         <ItemActions>
                             <ColorInput value={background.color} onChange={(color) => setBackgroundStyle({ color })} disabled={!background.enabled} />

--- a/src/components/settings/language-select.tsx
+++ b/src/components/settings/language-select.tsx
@@ -1,0 +1,29 @@
+import { useI18n } from "@/i18n";
+import { LanguagePreference, useKeyStyle } from "@/stores/key_style";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+export const LanguageSelect = () => {
+  const appearance = useKeyStyle((state) => state.appearance);
+  const setAppearance = useKeyStyle((state) => state.setAppearance);
+  const { systemLocale, t } = useI18n();
+
+  const systemLabel = systemLocale
+    ? `${t("System", "跟随系统")} (${systemLocale})`
+    : t("System", "跟随系统");
+
+  return (
+    <Select
+      value={appearance.language}
+      onValueChange={(language) => setAppearance({ language: language as LanguagePreference })}
+    >
+      <SelectTrigger className="w-40">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="system">{systemLabel}</SelectItem>
+        <SelectItem value="en">English</SelectItem>
+        <SelectItem value="zh-CN">中文</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+};

--- a/src/components/settings/mouse.tsx
+++ b/src/components/settings/mouse.tsx
@@ -1,10 +1,11 @@
 import { ColorInput } from "@/components/ui/color-picker";
+import { useI18n } from "@/i18n";
 import { Item, ItemActions, ItemContent, ItemDescription, ItemGrid, ItemTitle } from "@/components/ui/item";
 import { NumberInput } from "@/components/ui/number-input";
 import { Switch } from "@/components/ui/switch";
 import { useKeyEvent } from "@/stores/key_event";
 import { useKeyStyle } from '@/stores/key_style';
-import { ArrowExpand02Icon, Cursor01Icon, CursorCircleSelection01Icon, CursorEdit01Icon, CursorMagicSelection03FreeIcons, Drag03Icon, KeyboardIcon, Link02Icon, MouseLeftClick05Icon, PaintBoardIcon, Unlink02Icon } from "@hugeicons/core-free-icons";
+import { ArrowExpand02Icon, Cursor01Icon, CursorCircleSelection01Icon, CursorEdit01Icon, CursorMagicSelection03FreeIcons, Drag03Icon, Link02Icon, MouseLeftClick05Icon, PaintBoardIcon, Unlink02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { NumberScrubber } from "../ui/number-input-scrub";
 import { useState } from "react";
@@ -12,6 +13,7 @@ import { Toggle } from "../ui/toggle";
 
 
 export const MouseSettings = () => {
+    const { t } = useI18n();
     const mouse = useKeyStyle(state => state.mouse);
     const setMouseStyle = useKeyStyle(state => state.setMouse);
 
@@ -21,16 +23,16 @@ export const MouseSettings = () => {
     const [offsetLinked, setOffsetLinked] = useState(true);
 
     return <div className="flex flex-col gap-y-4 p-6">
-        <h1 className="text-xl font-semibold">Mouse</h1>
+        <h1 className="text-xl font-semibold">{t("Mouse", "鼠标")}</h1>
 
-        <h2 className="text-sm text-muted-foreground font-medium">Cursor Highlight</h2>
+        <h2 className="text-sm text-muted-foreground font-medium">{t("Cursor Highlight", "光标高亮")}</h2>
         <Item variant="muted">
             <ItemContent>
                 <ItemTitle>
-                    <HugeiconsIcon icon={CursorMagicSelection03FreeIcons} size="1em" /> Show Clicks
+                    <HugeiconsIcon icon={CursorMagicSelection03FreeIcons} size="1em" /> {t("Show Clicks", "显示点击")}
                 </ItemTitle>
                 <ItemDescription>
-                    Animate a ring upon mouse press
+                    {t("Animate a ring upon mouse press", "鼠标按下时显示动画圆环")}
                 </ItemDescription>
             </ItemContent>
             <ItemActions>
@@ -45,7 +47,7 @@ export const MouseSettings = () => {
             <Item variant="muted">
                 <ItemContent>
                     <ItemTitle>
-                        <HugeiconsIcon icon={CursorCircleSelection01Icon} size="1em" /> Size
+                        <HugeiconsIcon icon={CursorCircleSelection01Icon} size="1em" /> {t("Size", "尺寸")}
                     </ItemTitle>
                 </ItemContent>
                 <ItemActions>
@@ -61,7 +63,7 @@ export const MouseSettings = () => {
             <Item variant="muted">
                 <ItemContent>
                     <ItemTitle>
-                        <HugeiconsIcon icon={PaintBoardIcon} size="1em" /> Color
+                        <HugeiconsIcon icon={PaintBoardIcon} size="1em" /> {t("Color", "颜色")}
                     </ItemTitle>
                 </ItemContent>
                 <ItemActions>
@@ -78,10 +80,10 @@ export const MouseSettings = () => {
         <Item variant="muted">
             <ItemContent>
                 <ItemTitle>
-                    <HugeiconsIcon icon={Cursor01Icon} size="1em" /> Always Highlight
+                    <HugeiconsIcon icon={Cursor01Icon} size="1em" /> {t("Always Highlight", "始终高亮")}
                 </ItemTitle>
                 <ItemDescription>
-                    Permanently show the ring around the cursor
+                    {t("Permanently show the ring around the cursor", "始终显示光标周围的高亮圆环")}
                 </ItemDescription>
             </ItemContent>
             <ItemActions>
@@ -93,14 +95,14 @@ export const MouseSettings = () => {
             </ItemActions>
         </Item>
 
-        <h2 className="text-sm text-muted-foreground font-medium mt-2">Button Indicator</h2>
+        <h2 className="text-sm text-muted-foreground font-medium mt-2">{t("Button Indicator", "按键指示器")}</h2>
         <Item variant="muted">
             <ItemContent>
                 <ItemTitle>
-                    <HugeiconsIcon icon={MouseLeftClick05Icon} size="1em" /> Show Indicator
+                    <HugeiconsIcon icon={MouseLeftClick05Icon} size="1em" /> {t("Show Indicator", "显示指示器")}
                 </ItemTitle>
                 <ItemDescription>
-                    Display button and scroll icons next to the cursor
+                    {t("Display button and scroll icons next to the cursor", "在光标旁显示按键和滚轮图标")}
                 </ItemDescription>
             </ItemContent>
             <ItemActions>
@@ -114,10 +116,10 @@ export const MouseSettings = () => {
         <Item variant="muted">
             <ItemContent>
                 <ItemTitle>
-                    <HugeiconsIcon icon={Cursor01Icon} size="1em" /> Keep Indicator
+                    <HugeiconsIcon icon={Cursor01Icon} size="1em" /> {t("Keep Indicator", "常驻指示器")}
                 </ItemTitle>
                 <ItemDescription>
-                    Permanently show the icon beside the cursor
+                    {t("Permanently show the icon beside the cursor", "始终在光标旁显示图标")}
                 </ItemDescription>
             </ItemContent>
             <ItemActions>
@@ -132,7 +134,7 @@ export const MouseSettings = () => {
         <Item variant="muted">
             <ItemContent>
                 <ItemTitle>
-                    <HugeiconsIcon icon={CursorEdit01Icon} size="1em" /> Size
+                    <HugeiconsIcon icon={CursorEdit01Icon} size="1em" /> {t("Size", "尺寸")}
                 </ItemTitle>
             </ItemContent>
             <ItemActions>
@@ -147,10 +149,10 @@ export const MouseSettings = () => {
         <Item variant="muted">
             <ItemContent>
                 <ItemTitle>
-                    <HugeiconsIcon icon={ArrowExpand02Icon} size="1em" /> Offset
+                    <HugeiconsIcon icon={ArrowExpand02Icon} size="1em" /> {t("Offset", "偏移")}
                 </ItemTitle>
                 <ItemDescription>
-                    Space from the cursor to the indicator
+                    {t("Space from the cursor to the indicator", "指示器与光标之间的距离")}
                 </ItemDescription>
             </ItemContent>
             <ItemActions>
@@ -185,14 +187,14 @@ export const MouseSettings = () => {
             </ItemActions>
         </Item>
 
-        <h2 className="text-sm text-muted-foreground font-medium mt-2">Event</h2>
+        <h2 className="text-sm text-muted-foreground font-medium mt-2">{t("Event", "事件")}</h2>
         <Item variant="muted">
             <ItemContent>
                 <ItemTitle>
-                    <HugeiconsIcon icon={Drag03Icon} size="1em" /> Drag Threshold
+                    <HugeiconsIcon icon={Drag03Icon} size="1em" /> {t("Drag Threshold", "拖拽阈值")}
                 </ItemTitle>
                 <ItemDescription>
-                    Minimum distance in pixels to show Drag event
+                    {t("Minimum distance in pixels to show Drag event", "显示 Drag 事件所需的最小像素距离")}
                 </ItemDescription>
             </ItemContent>
             <ItemActions>

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -1,0 +1,71 @@
+import { locale as getSystemLocale } from "@tauri-apps/plugin-os";
+import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from "react";
+import { useKeyStyle } from "./stores/key_style";
+
+export type SupportedLanguage = "en" | "zh-CN";
+
+interface I18nContextValue {
+  language: SupportedLanguage;
+  systemLocale: string | null;
+  t: (english: string, chinese: string) => string;
+}
+
+const I18nContext = createContext<I18nContextValue>({
+  language: "en",
+  systemLocale: null,
+  t: (english) => english,
+});
+
+function normalizeLanguage(locale: string | null | undefined): SupportedLanguage {
+  if (locale?.toLowerCase().startsWith("zh")) {
+    return "zh-CN";
+  }
+  return "en";
+}
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const preference = useKeyStyle((state) => state.appearance.language);
+  const [systemLocale, setSystemLocale] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadLocale = async () => {
+      try {
+        const locale = await getSystemLocale();
+        if (mounted) {
+          setSystemLocale(locale ?? navigator.language ?? null);
+        }
+      } catch {
+        if (mounted) {
+          setSystemLocale(navigator.language ?? null);
+        }
+      }
+    };
+
+    loadLocale();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const language = useMemo<SupportedLanguage>(() => {
+    if (preference === "system") {
+      return normalizeLanguage(systemLocale);
+    }
+    return preference;
+  }, [preference, systemLocale]);
+
+  const value = useMemo<I18nContextValue>(() => ({
+    language,
+    systemLocale,
+    t: (english, chinese) => language === "zh-CN" ? chinese : english,
+  }), [language, systemLocale]);
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n() {
+  return useContext(I18nContext);
+}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { AboutPage, AppearanceSettings, GeneralSettings, KeycapSettings, MouseSettings } from "@/components/settings";
+import { useI18n } from "@/i18n";
 import { VERSION } from "@/components/settings/about";
 import { ThemeModeToggle } from "@/components/theme-mode-toggle";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -16,7 +17,25 @@ const sideBar = [
 ]
 
 const Settings = () => {
+    const { t } = useI18n();
     const [activeTab, setActiveTab] = useState(sideBar[0].title);
+
+    const localizedTitle = (title: string) => {
+        switch (title) {
+            case "General":
+                return t("General", "通用");
+            case "Appearance":
+                return t("Appearance", "外观");
+            case "Keycap":
+                return t("Keycap", "键帽");
+            case "Mouse":
+                return t("Mouse", "鼠标");
+            case "About":
+                return t("About", "关于");
+            default:
+                return title;
+        }
+    };
 
     return (
         <div className="flex w-screen h-screen overflow-hidden border-t bg-background">
@@ -31,13 +50,13 @@ const Settings = () => {
                 {
                     sideBar.map((item) => (
                         <a key={item.title} onClick={() => setActiveTab(item.title)} className="cursor-pointer">
-                            <SidebarItem item={item} isActive={activeTab === item.title} />
+                            <SidebarItem item={{ ...item, title: localizedTitle(item.title) }} isActive={activeTab === item.title} />
                         </a>
                     ))
                 }
                 <div className="mt-auto flex gap-2 items-center">
                     <a key="about" onClick={() => setActiveTab("About")} className="flex-1 cursor-pointer">
-                        <SidebarItem item={{ title: "About", icon: InformationSquareIcon }} isActive={activeTab === "About"} />
+                        <SidebarItem item={{ title: localizedTitle("About"), icon: InformationSquareIcon }} isActive={activeTab === "About"} />
                     </a>
                     <ThemeModeToggle />
                 </div>

--- a/src/pages/visualization.tsx
+++ b/src/pages/visualization.tsx
@@ -6,10 +6,12 @@ import { listenForUpdates } from '@/stores/sync';
 import { EventPayload } from "@/types/event";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect, useState, } from "react";
 
 export function Visualization() {
   const monitor = useKeyStyle((state) => state.appearance.monitor);
+  const alwaysOnTop = useKeyStyle((state) => state.appearance.alwaysOnTop);
   const onEvent = useKeyEvent((state) => state.onEvent);
   const tick = useKeyEvent((state) => state.tick);
 
@@ -49,6 +51,12 @@ export function Visualization() {
     }
     set_monitor();
   }, [monitor]);
+
+  useEffect(() => {
+    getCurrentWindow().setAlwaysOnTop(alwaysOnTop).catch((error) => {
+      console.error("Failed to update always-on-top state:", error);
+    });
+  }, [alwaysOnTop]);
 
   if (!isListening) return null;
 

--- a/src/stores/key_event.ts
+++ b/src/stores/key_event.ts
@@ -62,6 +62,20 @@ interface KeyEventActions {
 
 export type KeyEventStore = KeyEventState & KeyEventActions;
 
+const COMBINATION_KEYS = new Set<string>([
+    ...MODIFIERS,
+    RawKey.Left,
+    RawKey.Middle,
+    RawKey.Right,
+    RawKey.Drag,
+    RawKey.ScrollUp,
+    RawKey.ScrollDown,
+]);
+
+function shouldGroupKeyPress(pressedKeys: string[], keyName: string): boolean {
+    return pressedKeys.some((pressedKey) => COMBINATION_KEYS.has(pressedKey)) || COMBINATION_KEYS.has(keyName);
+}
+
 const createKeyEventStore = createSyncedStore<KeyEventStore>(
     KEY_EVENT_STORE,
     (set, get) => ({
@@ -192,7 +206,15 @@ const createKeyEventStore = createSyncedStore<KeyEventStore>(
                 }
                 // key combination
                 else {
-                    if (state.showEventHistory && groups[last].keys.some(gKey => !gKey.in(pressedKeys))) {
+                    const shouldGroup = shouldGroupKeyPress(pressedKeys, key.name);
+
+                    if (!shouldGroup) {
+                        if (state.showEventHistory) {
+                            groups.push({ keys: [key], createdAt });
+                        } else {
+                            groups = [{ keys: [key], createdAt }];
+                        }
+                    } else if (state.showEventHistory && groups[last].keys.some(gKey => !gKey.in(pressedKeys))) {
                         // history mode, partial combination, add new group
                         const groupKeys = groups[last].keys.filter(gKey => gKey.in(pressedKeys));
                         groupKeys.push(key);
@@ -226,15 +248,18 @@ const createKeyEventStore = createSyncedStore<KeyEventStore>(
 
             // update last pressed time
             const groups = [...state.groups];
-            const last = groups.length - 1;
+            let updated = false;
 
-            const kIndex = last >= 0 ? groups[last].keys.findIndex(key => key.name === event.name) : undefined;
-            if (kIndex && kIndex >= 0) {
-                groups[last].keys[kIndex].lastPressedAt = Date.now();
-                set({ pressedKeys, groups });
-            } else {
-                set({ pressedKeys });
+            for (let index = groups.length - 1; index >= 0; index--) {
+                const keyIndex = groups[index].keys.findIndex(key => key.name === event.name);
+                if (keyIndex >= 0) {
+                    groups[index].keys[keyIndex].lastPressedAt = Date.now();
+                    updated = true;
+                    break;
+                }
             }
+
+            set(updated ? { pressedKeys, groups } : { pressedKeys });
         },
         onMouseMove(event: MouseMoveEvent) {
             const state = get();

--- a/src/stores/key_style.ts
+++ b/src/stores/key_style.ts
@@ -8,6 +8,7 @@ import { open, save } from "@tauri-apps/plugin-dialog";
 import { toast } from "sonner";
 
 export const KEY_STYLE_STORE = "key_style_store";
+export type LanguagePreference = "system" | "en" | "zh-CN";
 
 export interface AppearanceSettings {
     monitor: string | null;
@@ -18,6 +19,8 @@ export interface AppearanceSettings {
     animation: "none" | "fade" | "zoom" | "float" | "slide";
     animationDuration: number;
     style: "minimal" | "laptop" | "lowprofile" | "pbt";
+    language: LanguagePreference;
+    alwaysOnTop: boolean;
 }
 
 export interface LayoutSettings {
@@ -111,6 +114,8 @@ const createKeyStyleStore = createSyncedStore<KeyStyleStore>(
             animation: "fade",
             animationDuration: 0.25,
             style: "lowprofile",
+            language: "system",
+            alwaysOnTop: true,
         },
         layout: {
             showIcon: true,
@@ -237,6 +242,21 @@ const createKeyStyleStore = createSyncedStore<KeyStyleStore>(
     (config) => persist(config, {
         name: KEY_STYLE_STORE,
         storage: createJSONStorage(() => tauriStorage),
+        merge: (persistedState, currentState) => {
+            const persisted = persistedState as Partial<KeyStyleState> | undefined;
+            return {
+                ...currentState,
+                ...persisted,
+                appearance: { ...currentState.appearance, ...persisted?.appearance },
+                layout: { ...currentState.layout, ...persisted?.layout },
+                color: { ...currentState.color, ...persisted?.color },
+                modifier: { ...currentState.modifier, ...persisted?.modifier },
+                text: { ...currentState.text, ...persisted?.text },
+                border: { ...currentState.border, ...persisted?.border },
+                background: { ...currentState.background, ...persisted?.background },
+                mouse: { ...currentState.mouse, ...persisted?.mouse },
+            };
+        },
     }),
 );
 


### PR DESCRIPTION
## Summary
- add lightweight i18n support with Simplified Chinese and use system language by default
- fix key linger expiration so released keys disappear after the configured duration
- stop grouping normal sequential letters into the same combo and disable text ligatures to avoid merged labels like `RU` or `HI`
- add an always-on-top toggle for the overlay and keep it enabled by default

## Details
- introduce a small frontend i18n layer and wire the main settings pages to Chinese and English labels
- fix release timestamp handling in the key event store so linger duration applies reliably
- restrict combo grouping to modifier and mouse-related combinations instead of normal letter sequences
- apply runtime window `alwaysOnTop` updates from settings so the overlay can stay above other apps

## Verification
- `npm run build`
- `npm run tauri build`
