### PR TITLE
feat: Add toggle to show/hide mouse actions in key overlay

### DIFF
--- a/src/components/settings/mouse.tsx
+++ b/src/components/settings/mouse.tsx
@@ -189,6 +189,23 @@ export const MouseSettings = () => {
         <Item variant="muted">
             <ItemContent>
                 <ItemTitle>
+                    <HugeiconsIcon icon={MouseLeftClick05Icon} size="1em" /> Show Mouse Actions
+                </ItemTitle>
+                <ItemDescription>
+                    Show clicks, drags, and scrolls in the key overlay
+                </ItemDescription>
+            </ItemContent>
+            <ItemActions>
+                <Switch
+                    checked={mouse.showMouseActions}
+                    onCheckedChange={(showMouseActions) => setMouseStyle({ showMouseActions })}
+                />
+            </ItemActions>
+        </Item>
+
+        <Item variant="muted">
+            <ItemContent>
+                <ItemTitle>
                     <HugeiconsIcon icon={Drag03Icon} size="1em" /> Drag Threshold
                 </ItemTitle>
                 <ItemDescription>

--- a/src/stores/key_event.ts
+++ b/src/stores/key_event.ts
@@ -3,6 +3,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { tauriStorage } from "./storage";
 import { createSyncedStore } from "./sync";
+import { useKeyStyle } from "./key_style";
 
 
 export const KEY_EVENT_STORE = "key_event_store";
@@ -271,8 +272,7 @@ const createKeyEventStore = createSyncedStore<KeyEventStore>(
                         state.allowedKeys.includes("Drag")
                     );
 
-                    if (hasGroupKeys || dragAllowed) {
-                        // simulate drag as key press
+                    if ((hasGroupKeys || dragAllowed) && useKeyStyle.getState().mouse.showMouseActions) {
                         state.onKeyPress({ type: "KeyEvent", name: "Drag", pressed: true });
                     }
                     return;
@@ -282,14 +282,14 @@ const createKeyEventStore = createSyncedStore<KeyEventStore>(
         },
         onMouseButtonPress(event: MouseButtonEvent) {
             const state = get();
-            // set drag start position
             const mouse = {
                 ...state.mouse,
                 dragStart: { x: state.mouse.x, y: state.mouse.y },
             };
 
-            // simulate mouse button press as key
-            state.onKeyPress({ type: "KeyEvent", name: event.button.toString(), pressed: true });
+            if (useKeyStyle.getState().mouse.showMouseActions) {
+                state.onKeyPress({ type: "KeyEvent", name: event.button.toString(), pressed: true });
+            }
 
             set({
                 pressedMouseButton: event.button,
@@ -298,19 +298,17 @@ const createKeyEventStore = createSyncedStore<KeyEventStore>(
         },
         onMouseButtonRelease(event: MouseButtonEvent) {
             const state = get();
-            // reset drag state
             const mouse = {
                 ...state.mouse,
                 dragging: false,
                 dragStart: undefined
             };
-            // check if was dragging
-            if (state.mouse.dragging) {
-                // simulate drag release as key
-                state.onKeyRelease({ type: "KeyEvent", name: "Drag", pressed: false });
-            } else {
-                // simulate mouse button release as key
-                state.onKeyRelease({ type: "KeyEvent", name: event.button.toString(), pressed: false });
+            if (useKeyStyle.getState().mouse.showMouseActions) {
+                if (state.mouse.dragging) {
+                    state.onKeyRelease({ type: "KeyEvent", name: "Drag", pressed: false });
+                } else {
+                    state.onKeyRelease({ type: "KeyEvent", name: event.button.toString(), pressed: false });
+                }
             }
             set({
                 pressedMouseButton: null,
@@ -341,8 +339,7 @@ const createKeyEventStore = createSyncedStore<KeyEventStore>(
                 wheel, // -1 for down, 1 for up
                 lastScrollAt: Date.now()
             };
-            // simulate mouse wheel as key press
-            if (!get().pressedKeys.includes(raw_key)) {
+            if (!get().pressedKeys.includes(raw_key) && useKeyStyle.getState().mouse.showMouseActions) {
                 state.onKeyPress({ type: "KeyEvent", name: raw_key, pressed: true });
             }
 

--- a/src/stores/key_style.ts
+++ b/src/stores/key_style.ts
@@ -62,6 +62,7 @@ export interface BackgroundSettings {
 }
 
 export interface MouseSettings {
+    showMouseActions: boolean;
     showClicks: boolean;
     size: number;
     color: string;
@@ -148,6 +149,7 @@ const createKeyStyleStore = createSyncedStore<KeyStyleStore>(
             color: "#ffffff99",
         },
         mouse: {
+            showMouseActions: true,
             showClicks: false,
             size: 150,
             color: "#009dff",


### PR DESCRIPTION
## Summary

Fixes: https://github.com/mulaRahul/keyviz/issues/465

Right now there's no way to turn off mouse actions (clicks, drags, scrolls) appearing in the key overlay. Useful if you're recording and don't want the noise, or just prefer keyboard-only output.

This adds a \"Show Mouse Actions\" toggle in Settings > Mouse > Event. It defaults to on, so nothing changes for existing users.


## What changed

`key_style.ts` - added `showMouseActions: boolean` to the `MouseSettings` interface, default `true`

`key_event.ts` - imported `useKeyStyle` and wrapped `onMouseButtonPress`, `onMouseButtonRelease`, drag simulation in `onMouseMove`, and `onMouseWheel` behind the setting check

`src/components/settings/mouse.tsx` - added the toggle UI in the Event section, reusing the already-imported `MouseLeftClick05Icon`

## Note

All code changes in this PR were written by Claude, an AI agent. I reviewed the diff and verified the approach fits the existing patterns in the codebase before submitting.


