### PR TITLE
fix: remove unused KeyboardIcon import blocking tsc build

### DIFF
--- a/src/components/settings/mouse.tsx
+++ b/src/components/settings/mouse.tsx
@@ -4,7 +4,7 @@ import { NumberInput } from "@/components/ui/number-input";
 import { Switch } from "@/components/ui/switch";
 import { useKeyEvent } from "@/stores/key_event";
 import { useKeyStyle } from '@/stores/key_style';
-import { ArrowExpand02Icon, Cursor01Icon, CursorCircleSelection01Icon, CursorEdit01Icon, CursorMagicSelection03FreeIcons, Drag03Icon, KeyboardIcon, Link02Icon, MouseLeftClick05Icon, PaintBoardIcon, Unlink02Icon } from "@hugeicons/core-free-icons";
+import { ArrowExpand02Icon, Cursor01Icon, CursorCircleSelection01Icon, CursorEdit01Icon, CursorMagicSelection03FreeIcons, Drag03Icon, Link02Icon, MouseLeftClick05Icon, PaintBoardIcon, Unlink02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { NumberScrubber } from "../ui/number-input-scrub";
 import { useState } from "react";


### PR DESCRIPTION
## Summary

Fixes: https://github.com/mulaRahul/keyviz/issues/467

- Removes unused `KeyboardIcon` import in `src/components/settings/mouse.tsx` that was blocking `tsc` build

## Test plan

- [x] Run `tsc` — build should complete without errors
