### PR TITLE
fix: silence rdev compiler warnings

### DIFF
--- a/src-tauri/crates/rdev/src/keycodes/android.rs
+++ b/src-tauri/crates/rdev/src/keycodes/android.rs
@@ -67,7 +67,7 @@ decl_keycodes!(
     ScrollLock, 116,
     NumLock, 143,
     Pause, 121,
-    BackQuote, 75,
+    BackQuote, 68,
     Num1, 8,
     Num2, 9,
     Num3, 10,

--- a/src-tauri/crates/rdev/src/keycodes/chrome.rs
+++ b/src-tauri/crates/rdev/src/keycodes/chrome.rs
@@ -13,6 +13,7 @@ macro_rules! decl_keycodes {
             }
         }
 
+        #[allow(unreachable_patterns)]
         pub fn key_from_code(code: &str) -> Key {
             match code {
                 $(

--- a/src-tauri/crates/rdev/src/windows/grab.rs
+++ b/src-tauri/crates/rdev/src/windows/grab.rs
@@ -69,7 +69,7 @@ unsafe fn raw_callback(
                 usb_hid: 0,
                 extra_data: f_get_extra_data(lpdata),
             };
-            if let Some(callback) = &mut GLOBAL_CALLBACK {
+            if let Some(callback) = &mut *std::ptr::addr_of_mut!(GLOBAL_CALLBACK) {
                 if callback(event).is_none() {
                     // https://stackoverflow.com/questions/42756284/blocking-windows-mouse-click-using-setwindowshookex
                     // https://android.developreference.com/article/14560004/Blocking+windows+mouse+click+using+SetWindowsHookEx()

--- a/src-tauri/crates/rdev/src/windows/listen.rs
+++ b/src-tauri/crates/rdev/src/windows/listen.rs
@@ -40,7 +40,7 @@ unsafe fn raw_callback(
                 usb_hid: 0,
                 extra_data: f_get_extra_data(lpdata),
             };
-            if let Some(callback) = &mut GLOBAL_CALLBACK {
+            if let Some(callback) = &mut *std::ptr::addr_of_mut!(GLOBAL_CALLBACK) {
                 callback(event);
             }
         }


### PR DESCRIPTION
## Summary

Fixes: https://github.com/mulaRahul/keyviz/issues/468

- `android.rs`: fix `BackQuote` keycode 75→68 (duplicate of `Quote`; correct is `KEYCODE_GRAVE`)
- `chrome.rs`: add `#[allow(unreachable_patterns)]` — multiple keys legitimately map to `""` in Chrome
- `windows/grab.rs`, `listen.rs`: `&mut GLOBAL_CALLBACK` → `&mut *addr_of_mut!(GLOBAL_CALLBACK)` to avoid `static_mut_refs` UB

## Test plan

- [x] Build compiles without warnings on Windows, Android, Chrome targets (only tested win)