### PR TITLE
🍎 toggle switcher for settings

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>LSUIElement</key>
+  <true/>
+</dict>
+</plist>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,11 +1,13 @@
 use std::sync::Mutex;
 
+#[cfg(target_os = "macos")]
+use tauri::ActivationPolicy;
 use tauri::{
     image::Image,
     include_image,
     menu::{Menu, MenuItem},
     tray::TrayIconBuilder,
-    Emitter, Manager, WebviewWindowBuilder,
+    AppHandle, Emitter, Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder,
 };
 
 mod app;
@@ -13,6 +15,82 @@ use app::commands::{log, set_main_window_monitor, set_toggle_shortcut};
 use app::event::start_listener;
 use app::state::AppState;
 use app::window::config_window;
+
+#[cfg(target_os = "macos")]
+fn set_settings_switcher_visibility(app: &AppHandle, visible: bool) {
+    let activation_policy = if visible {
+        ActivationPolicy::Regular
+    } else {
+        ActivationPolicy::Accessory
+    };
+
+    if let Err(err) = app.set_activation_policy(activation_policy) {
+        eprintln!("Failed to set activation policy: {err}");
+    }
+
+    if let Err(err) = app.set_dock_visibility(visible) {
+        eprintln!("Failed to set dock visibility: {err}");
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn set_settings_switcher_visibility(_app: &AppHandle, _visible: bool) {}
+
+fn emit_settings_window_state(app: &AppHandle, visible: bool) {
+    let _ = app.emit_to("main", "settings-window", visible);
+}
+
+fn build_settings_window(app: &AppHandle) -> tauri::Result<WebviewWindow> {
+    let webview_url = WebviewUrl::App("index.html#/settings".into());
+
+    WebviewWindowBuilder::new(app, "settings", webview_url)
+        .title("Keyviz")
+        .inner_size(800.0, 640.0)
+        .min_inner_size(640.0, 480.0)
+        .max_inner_size(1000.0, 800.0)
+        .maximizable(false)
+        .build()
+}
+
+fn show_settings_window(app: &AppHandle) {
+    set_settings_switcher_visibility(app, true);
+
+    #[cfg(target_os = "macos")]
+    let _ = app.show();
+
+    let window = match app.get_webview_window("settings") {
+        Some(window) => window,
+        None => match build_settings_window(app) {
+            Ok(window) => window,
+            Err(err) => {
+                eprintln!("Failed to create settings window: {err}");
+                set_settings_switcher_visibility(app, false);
+
+                #[cfg(target_os = "macos")]
+                let _ = app.hide();
+
+                return;
+            }
+        },
+    };
+
+    let _ = window.unminimize();
+    let _ = window.show();
+    let _ = window.set_focus();
+    emit_settings_window_state(app, true);
+}
+
+fn hide_settings_window(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window("settings") {
+        let _ = window.hide();
+    }
+
+    emit_settings_window_state(app, false);
+    set_settings_switcher_visibility(app, false);
+
+    #[cfg(target_os = "macos")]
+    let _ = app.hide();
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -54,27 +132,16 @@ pub fn run() {
                         let mut app_state = state.lock().unwrap();
                         app_state.toggle_listener(app, &toggle_item);
                     }
-                    "settings" => {
-                        if let Some(window) = app.get_webview_window("settings") {
-                            let _ = window.set_focus();
-                            return;
-                        }
-                        let webview_url = tauri::WebviewUrl::App("index.html#/settings".into());
-                        WebviewWindowBuilder::new(app, "settings", webview_url.clone())
-                            .title("Keyviz")
-                            .inner_size(800.0, 640.0)
-                            .min_inner_size(640.0, 480.0)
-                            .max_inner_size(1000.0, 800.0)
-                            .maximizable(false)
-                            .build()
-                            .unwrap();
-
-                        app.emit_to("main", "settings-window", true).unwrap();
-                    }
+                    "settings" => show_settings_window(app),
                     "quit" => std::process::exit(0),
                     _ => println!("um... what?"),
                 })
                 .build(app);
+
+            set_settings_switcher_visibility(&app_handle, false);
+
+            #[cfg(target_os = "macos")]
+            let _ = app_handle.hide();
 
             Ok(())
         })
@@ -82,14 +149,10 @@ pub fn run() {
             if window.label() != "settings" {
                 return;
             }
-            match event {
-                tauri::WindowEvent::CloseRequested { .. } => {
-                    window
-                        .app_handle()
-                        .emit_to("main", "settings-window", false)
-                        .unwrap();
-                }
-                _ => {}
+
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                api.prevent_close();
+                hide_settings_window(&window.app_handle());
             }
         })
         .invoke_handler(tauri::generate_handler![

--- a/src/components/settings/mouse.tsx
+++ b/src/components/settings/mouse.tsx
@@ -4,7 +4,7 @@ import { NumberInput } from "@/components/ui/number-input";
 import { Switch } from "@/components/ui/switch";
 import { useKeyEvent } from "@/stores/key_event";
 import { useKeyStyle } from '@/stores/key_style';
-import { ArrowExpand02Icon, Cursor01Icon, CursorCircleSelection01Icon, CursorEdit01Icon, CursorMagicSelection03FreeIcons, Drag03Icon, KeyboardIcon, Link02Icon, MouseLeftClick05Icon, PaintBoardIcon, Unlink02Icon } from "@hugeicons/core-free-icons";
+import { ArrowExpand02Icon, Cursor01Icon, CursorCircleSelection01Icon, CursorEdit01Icon, CursorMagicSelection03FreeIcons, Drag03Icon, Link02Icon, MouseLeftClick05Icon, PaintBoardIcon, Unlink02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { NumberScrubber } from "../ui/number-input-scrub";
 import { useState } from "react";


### PR DESCRIPTION
## Summary

This PR fixes #436 by keeping Keyviz hidden from the macOS Dock and app switcher during normal tray-only use, while still showing it as a regular app when the settings window is opened.

## Root cause

Keyviz was previously running with the default macOS activation policy, so the app could still appear in the Dock and `Cmd+Tab` app switcher even when it was effectively being used as a tray-first utility.

The settings window also followed a close flow that did not switch the app back to a tray-only state after it was dismissed.

## Changes

- add a macOS `Info.plist` with `LSUIElement` so the app starts in a menu bar style mode
- switch the app activation policy and dock visibility when opening or hiding the settings window
- intercept the settings window close request so `Cmd+W` and the titlebar close button hide the window and return the app to tray-only mode
- remove an unused frontend import so the production build stays green

## Testing

- `cargo check`
- `npm run build`
- `npm run tauri build`
- manually verified on macOS that:
  - opening Settings from the tray shows Keyviz in the app switcher
  - closing Settings with `Cmd+W` or the close button removes Keyviz from the app switcher again

## Result

### Settings open: Keyviz appears in the macOS app switcher while the settings window is visible.
<img width="1264" height="756" alt="image" src="https://github.com/user-attachments/assets/b7b84b61-a7e5-4d27-a592-ffecb5716607" />

### Settings closed: Keyviz returns to tray-only mode and no longer appears in the macOS app switcher after the settings window is dismissed.
<img width="1268" height="682" alt="image" src="https://github.com/user-attachments/assets/201604d4-a504-4ec0-9909-a4f006aab899" />